### PR TITLE
Slå sammen journalføring-arena og journalføring-ferdigstill

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,11 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
+val cxfVersion = "3.3.4"
+val tjenestespesifikasjonerVersion = "1.2019.09.25-00.21-49b69f0625e0"
+
+fun tjenestespesifikasjon(name: String) = "no.nav.tjenestespesifikasjoner:$name:$tjenestespesifikasjonerVersion"
+
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(Dagpenger.Events)
@@ -62,6 +67,7 @@ dependencies {
     implementation(Log4j2.core)
     implementation(Log4j2.slf4j)
     implementation(Log4j2.Logstash.logstashLayout)
+    implementation(Ulid.ulid)
 
     api(Kafka.clients)
     api(Kafka.streams)
@@ -77,6 +83,23 @@ dependencies {
     testImplementation(Wiremock.standalone)
 
     testRuntimeOnly(Junit5.engine)
+
+    // Soap stuff
+    implementation("javax.xml.ws:jaxws-api:2.3.1")
+    implementation("com.sun.xml.ws:jaxws-tools:2.3.0.2")
+
+    implementation(tjenestespesifikasjon("behandleArbeidOgAktivitetOppgave-v1-tjenestespesifikasjon"))
+    implementation(tjenestespesifikasjon("ytelseskontrakt-v3-tjenestespesifikasjon"))
+
+    implementation("org.apache.cxf:cxf-rt-features-logging:$cxfVersion")
+    implementation("org.apache.cxf:cxf-rt-frontend-jaxws:$cxfVersion")
+    implementation("org.apache.cxf:cxf-rt-ws-policy:$cxfVersion")
+    implementation("org.apache.cxf:cxf-rt-ws-security:$cxfVersion")
+    implementation("org.apache.cxf:cxf-rt-transports-http:$cxfVersion")
+    implementation("javax.activation:activation:1.1.1")
+    implementation("no.nav.helse:cxf-prometheus-metrics:dd7d125")
+    testImplementation("org.apache.cxf:cxf-rt-transports-http:$cxfVersion")
+    // Soap stuff end
 }
 
 spotless {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import Mockk.mockk
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
@@ -124,4 +126,19 @@ tasks.withType<Test> {
         exceptionFormat = TestExceptionFormat.FULL
         events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
     }
+}
+
+tasks.withType<ShadowJar> {
+    mergeServiceFiles()
+
+    // Make sure the cxf service files are handled correctly so that the SOAP services work.
+    // Ref https://stackoverflow.com/questions/45005287/serviceconstructionexception-when-creating-a-cxf-web-service-client-scalajava
+    transform(ServiceFileTransformer::class.java) {
+        setPath("META-INF/cxf")
+        include("bus-extensions.txt")
+    }
+}
+
+tasks.named("shadowJar") {
+    dependsOn("test")
 }

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Application.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Application.kt
@@ -2,10 +2,10 @@ package no.nav.dagpenger.journalføring.ferdigstill
 
 import mu.KotlinLogging
 import no.nav.dagpenger.events.Packet
-import no.nav.dagpenger.journalføring.arena.adapter.ArenaClient
-import no.nav.dagpenger.journalføring.arena.adapter.soap.SoapPort
 import no.nav.dagpenger.journalføring.ferdigstill.PacketKeys.JOURNALPOST_ID
 import no.nav.dagpenger.journalføring.ferdigstill.PacketKeys.TOGGLE_BEHANDLE_NY_SØKNAD
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaClient
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.SoapPort
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.arena.SoapArenaClient
 import no.nav.dagpenger.oidc.StsOidcClient
 import no.nav.dagpenger.streams.Pond

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Configuration.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Configuration.kt
@@ -27,6 +27,8 @@ private val localProperties = ConfigurationMap(
         "srvdagpenger.journalforing.ferdigstill.password" to "password",
         "srvdagpenger.journalforing.ferdigstill.username" to "user",
         "sts.url" to "http://localhost",
+        "behandlearbeidsytelsesak.v1.url" to "https://localhost/ail_ws/BehandleArbeidOgAktivitetOppgave_v1",
+        "ytelseskontrakt.v3.url" to "https://localhost/ail_ws/Ytelseskontrakt_v3",
         "kafka.processing.guarantee" to StreamsConfig.AT_LEAST_ONCE
 
     )
@@ -40,6 +42,8 @@ private val devProperties = ConfigurationMap(
         "gosysApi.url" to "http://oppgave.default.svc.nais.local",
         "kafka.bootstrap.servers" to "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443",
         "sts.url" to "http://security-token-service.default.svc.nais.local",
+        "behandlearbeidsytelsesak.v1.url" to "https://arena-q1.adeo.no/ail_ws/BehandleArbeidOgAktivitetOppgave_v1",
+        "ytelseskontrakt.v3.url" to "https://arena-q1.adeo.no/ail_ws/Ytelseskontrakt_v3",
         "kafka.processing.guarantee" to StreamsConfig.AT_LEAST_ONCE
     )
 )
@@ -52,6 +56,8 @@ private val prodProperties = ConfigurationMap(
         "gosysApi.url" to "http://oppgave.default.svc.nais.local",
         "kafka.bootstrap.servers" to "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443",
         "sts.url" to "http://security-token-service.default.svc.nais.local",
+        "behandlearbeidsytelsesak.v1.url" to "https://arena.adeo.no/ail_ws/BehandleArbeidOgAktivitetOppgave_v1",
+        "ytelseskontrakt.v3.url" to "https://arena.adeo.no/ail_ws/Ytelseskontrakt_v3",
         "kafka.processing.guarantee" to StreamsConfig.EXACTLY_ONCE
     )
 )
@@ -73,6 +79,8 @@ data class Configuration(
     val application: Application = Application(),
     val journalPostApiUrl: String = config()[Key("journalPostApi.url", stringType)],
     val gosysApiUrl: String = config()[Key("gosysApi.url", stringType)],
+    val behandleArbeidsytelseSakConfig: BehandleArbeidsytelseSakConfig = BehandleArbeidsytelseSakConfig(),
+    val ytelseskontraktV3Config: YtelseskontraktV3Config = YtelseskontraktV3Config(),
     val sts: Sts = Sts()
 ) {
 
@@ -100,6 +108,15 @@ data class Configuration(
         val profile: Profile = config()[Key("application.profile", stringType)].let { Profile.valueOf(it) },
         val httpPort: Int = config()[Key("application.httpPort", intType)],
         val name: String = config()[Key("application.name", stringType)]
+    )
+
+
+    data class BehandleArbeidsytelseSakConfig(
+        val endpoint: String = config()[Key("behandlearbeidsytelsesak.v1.url", stringType)]
+    )
+
+    data class YtelseskontraktV3Config(
+        val endpoint: String = config()[Key("ytelseskontrakt.v3.url", stringType)]
     )
 }
 

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Configuration.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Configuration.kt
@@ -110,7 +110,6 @@ data class Configuration(
         val name: String = config()[Key("application.name", stringType)]
     )
 
-
     data class BehandleArbeidsytelseSakConfig(
         val endpoint: String = config()[Key("behandlearbeidsytelsesak.v1.url", stringType)]
     )

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/GosysOppgaveClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/GosysOppgaveClient.kt
@@ -12,13 +12,13 @@ import java.time.LocalDate
 
 private val logger = KotlinLogging.logger {}
 
-internal interface OppgaveClient {
-    fun opprettOppgave(journalPostId: String, aktørId: String, søknadstittel: String, tildeltEnhetsnr: String)
+internal interface ManuellJournalføringsOppgaveClient {
+    fun opprettOppgave(journalPostId: String, aktørId: String?, søknadstittel: String, tildeltEnhetsnr: String)
 }
 
 internal data class GosysOppgave(
     val journalpostId: String,
-    val aktoerId: String,
+    val aktoerId: String?,
     val tildeltEnhetsnr: String,
     val beskrivelse: String = "Kunne ikke automatisk journalføres",
     val opprettetAvEnhetsnr: String = "9999",
@@ -29,7 +29,7 @@ internal data class GosysOppgave(
     val prioritet: String = "NORM"
 )
 
-internal class GosysOppgaveClient(private val url: String, private val oidcClient: OidcClient) : OppgaveClient {
+internal class GosysOppgaveClient(private val url: String, private val oidcClient: OidcClient) : ManuellJournalføringsOppgaveClient {
 
     companion object {
         private val moishiInstance = Moshi.Builder()
@@ -40,7 +40,7 @@ internal class GosysOppgaveClient(private val url: String, private val oidcClien
         fun toOpprettGosysOppgaveJsonPayload(gosysOppgave: GosysOppgave) = moishiInstance.adapter<GosysOppgave>(GosysOppgave::class.java).toJson(gosysOppgave)
     }
 
-    override fun opprettOppgave(journalPostId: String, aktørId: String, søknadstittel: String, tildeltEnhetsnr: String) {
+    override fun opprettOppgave(journalPostId: String, aktørId: String?, søknadstittel: String, tildeltEnhetsnr: String) {
         val (_, _, result) = url.plus("/api/v1/oppgaver")
             .httpPost()
             .authentication()

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalFøringFerdigstill.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalFøringFerdigstill.kt
@@ -6,10 +6,8 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import mu.KotlinLogging
 import no.nav.dagpenger.events.Packet
 import no.nav.dagpenger.events.moshiInstance
-import no.nav.dagpenger.journalføring.arena.adapter.ArenaClient
-import no.nav.dagpenger.journalføring.arena.adapter.ArenaSakStatus
-import no.nav.dagpenger.journalføring.arena.adapter.BestillOppgaveArenaException
-import no.nav.dagpenger.journalføring.arena.adapter.createArenaTilleggsinformasjon
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.BestillOppgaveArenaException
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.createArenaTilleggsinformasjon
 import no.nav.dagpenger.journalføring.ferdigstill.PacketKeys.AKTØR_ID
 import no.nav.dagpenger.journalføring.ferdigstill.PacketKeys.BEHANDLENDE_ENHET
 import no.nav.dagpenger.journalføring.ferdigstill.PacketKeys.NATURLIG_IDENT
@@ -22,6 +20,8 @@ import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.jo
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.registrertDatoFrom
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.tildeltEnhetsNrFrom
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.tittelFrom
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaClient
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaSakStatus
 import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.BestillOppgavePersonErInaktiv
 import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.BestillOppgavePersonIkkeFunnet
 import org.apache.kafka.streams.kstream.Predicate
@@ -67,14 +67,6 @@ internal object PacketToJoarkPayloadMapper {
         packet.getObjectValue(PacketKeys.DOKUMENTER) { dokumentAdapter.fromJsonValue(it)!! }.map { it.tittel }
 
     fun tittelFrom(packet: Packet) = dokumenterFrom(packet).first().tittel
-    fun sakFrom(packet: Packet) = when (packet.hasField(PacketKeys.ARENA_SAK_ID)) {
-        true -> Sak(
-            saksType = SaksType.FAGSAK,
-            fagsaksystem = "AO01",
-            fagsakId = packet.getStringValue(PacketKeys.ARENA_SAK_ID)
-        )
-        else -> Sak(SaksType.GENERELL_SAK, null, null)
-    }
 
     fun journalPostFrom(packet: Packet, fagsakId: String): OppdaterJournalPostPayload {
         return OppdaterJournalPostPayload(

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalFøringFerdigstill.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalFøringFerdigstill.kt
@@ -21,6 +21,7 @@ import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.do
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.hasNaturligIdent
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.journalPostFrom
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.journalPostIdFrom
+import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.nullableAktørFrom
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.registrertDatoFrom
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.tildeltEnhetsNrFrom
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.tittelFrom
@@ -59,7 +60,8 @@ internal object PacketToJoarkPayloadMapper {
     fun avsenderFrom(packet: Packet) = Avsender(packet.getStringValue(PacketKeys.AVSENDER_NAVN))
     fun brukerFrom(packet: Packet) = Bruker(packet.getStringValue(NATURLIG_IDENT))
     fun hasNaturligIdent(packet: Packet) = packet.hasField(NATURLIG_IDENT)
-    fun aktørFrom(packet: Packet) =
+    fun aktørFrom(packet: Packet) = Bruker(packet.getStringValue(AKTØR_ID), "AKTØR")
+    fun nullableAktørFrom(packet: Packet) =
         if (packet.hasField(AKTØR_ID)) Bruker(packet.getStringValue(AKTØR_ID), "AKTØR") else null
 
     fun tildeltEnhetsNrFrom(packet: Packet) = packet.getStringValue(BEHANDLENDE_ENHET)
@@ -98,7 +100,7 @@ internal class JournalFøringFerdigstill(
         val journalpostId = journalPostIdFrom(packet)
 
         if (kanBestilleFagsak(packet)) {
-            val aktørId = aktørFrom(packet)!!.id
+            val aktørId = aktørFrom(packet).id
 
             try {
                 val fagsakId = bestillFagsak(packet)
@@ -119,7 +121,7 @@ internal class JournalFøringFerdigstill(
         } else {
             manuellJournalføringsOppgaveClient.opprettOppgave(
                 journalpostId,
-                aktørFrom(packet)?.id,
+                nullableAktørFrom(packet)?.id,
                 tittelFrom(packet),
                 tildeltEnhetsNrFrom(packet)
             )

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Metrics.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Metrics.kt
@@ -18,4 +18,25 @@ internal object Metrics {
         .register()
 
     fun jpFerdigStillInc(saksType: SaksType) = jpFerdigstiltCounter.labels(saksType.name.toLowerCase()).inc()
+
+    val automatiskJournalførtTeller = Counter
+        .build()
+        .name("automatisk_journalfort_arena")
+        .help("Antall søknader som er automatisk journalført i Arena")
+        .labelNames("opprettet", "grunn")
+        .register()
+
+    val automatiskJournalførtJaTeller = automatiskJournalførtTeller.labels("true", "arena_ok")
+    fun automatiskJournalførtNeiTeller(reason: String) = automatiskJournalførtTeller.labels("false", reason).inc()
+
+    val antallDagpengerSaker = Counter
+        .build()
+        .name("dagpenger_saker")
+        .help("Antall dagpengesaker basert på status")
+        .labelNames("status")
+        .register()
+
+    val aktiveDagpengeSakTeller = antallDagpengerSaker.labels("aktiv")
+    val avsluttetDagpengeSakTeller = antallDagpengerSaker.labels("avsluttet")
+    val inaktivDagpengeSakTeller = antallDagpengerSaker.labels("inaktiv")
 }

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketKeys.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketKeys.kt
@@ -5,8 +5,6 @@ internal object PacketKeys {
     const val JOURNALPOST_ID: String = "journalpostId"
     const val NATURLIG_IDENT: String = "naturligIdent"
     const val AKTØR_ID: String = "aktørId"
-    const val ARENA_SAK_OPPRETTET: String = "arenaSakOpprettet"
-    const val ARENA_SAK_ID: String = "arenaSakId"
     const val DOKUMENTER: String = "dokumenter"
     const val TOGGLE_BEHANDLE_NY_SØKNAD: String = "toggleBehandleNySøknad"
     const val BEHANDLENDE_ENHET: String = "behandlendeEnhet"

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketKeys.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketKeys.kt
@@ -3,11 +3,12 @@ package no.nav.dagpenger.journalføring.ferdigstill
 internal object PacketKeys {
     const val AVSENDER_NAVN: String = "avsenderNavn"
     const val JOURNALPOST_ID: String = "journalpostId"
-    const val FNR: String = "naturligIdent"
+    const val NATURLIG_IDENT: String = "naturligIdent"
     const val AKTØR_ID: String = "aktørId"
     const val ARENA_SAK_OPPRETTET: String = "arenaSakOpprettet"
     const val ARENA_SAK_ID: String = "arenaSakId"
     const val DOKUMENTER: String = "dokumenter"
     const val TOGGLE_BEHANDLE_NY_SØKNAD: String = "toggleBehandleNySøknad"
     const val BEHANDLENDE_ENHET: String = "behandlendeEnhet"
+    const val DATO_REGISTRERT: String = "datoRegistrert"
 }

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaClient.kt
@@ -1,0 +1,8 @@
+package no.nav.dagpenger.journalføring.arena.adapter
+
+import no.nav.dagpenger.streams.HealthCheck
+
+interface ArenaClient : HealthCheck {
+    fun bestillOppgave(naturligIdent: String, behandlendeEnhetId: String, tilleggsinformasjon: String): String
+    fun hentArenaSaker(naturligIdent: String): List<ArenaSak>
+}

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaClient.kt
@@ -1,4 +1,4 @@
-package no.nav.dagpenger.journalføring.arena.adapter
+package no.nav.dagpenger.journalføring.ferdigstill.adapter
 
 import no.nav.dagpenger.streams.HealthCheck
 

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaClientException.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaClientException.kt
@@ -1,0 +1,6 @@
+package no.nav.dagpenger.journalføring.arena.adapter
+
+open class ArenaClientException(e: Exception) : RuntimeException(e)
+
+class BestillOppgaveArenaException(e: Exception) : ArenaClientException(e)
+class HentArenaSakerException(e: Exception) : ArenaClientException(e)

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaClientException.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaClientException.kt
@@ -1,4 +1,4 @@
-package no.nav.dagpenger.journalføring.arena.adapter
+package no.nav.dagpenger.journalføring.ferdigstill.adapter
 
 open class ArenaClientException(e: Exception) : RuntimeException(e)
 

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaSak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaSak.kt
@@ -1,4 +1,4 @@
-package no.nav.dagpenger.journalføring.arena.adapter
+package no.nav.dagpenger.journalføring.ferdigstill.adapter
 
 data class ArenaSakId(val id: String)
 

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaSak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaSak.kt
@@ -1,0 +1,9 @@
+package no.nav.dagpenger.journalføring.arena.adapter
+
+data class ArenaSakId(val id: String)
+
+data class ArenaSak(val fagsystemSakId: Int, val status: ArenaSakStatus)
+
+enum class ArenaSakStatus {
+    Aktiv, Inaktiv, Lukket
+}

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaTilleggsinformasjon.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaTilleggsinformasjon.kt
@@ -1,0 +1,32 @@
+package no.nav.dagpenger.journalføring.arena.adapter
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+fun createArenaTilleggsinformasjon(dokumentTitler: List<String>, registrertDato: String): String {
+    val hovedDokument = dokumentTitler.first()
+    val vedlegg = dokumentTitler.drop(1)
+
+    val formatertVedlegg =
+        if (vedlegg.isNotEmpty()) {
+            vedlegg.joinToString(prefix = "- ", separator = "\n- ", postfix = "\n")
+        } else {
+            ""
+        }
+
+    val formatertDato = formattedDateOrNull(registrertDato)?.let { "Registrert dato: ${it}\n" } ?: ""
+
+    return "Hoveddokument: ${hovedDokument}\n" +
+        formatertVedlegg +
+        formatertDato +
+        "Dokumentet er skannet inn og journalført automatisk av digitale dagpenger. Gjennomfør rutinen \"Etterkontroll av automatisk journalførte dokumenter\"."
+}
+
+fun formattedDateOrNull(dato: String): String? {
+    return try {
+        LocalDateTime.parse(dato).toLocalDate().format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+    } catch (e: DateTimeParseException) {
+        null
+    }
+}

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaTilleggsinformasjon.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaTilleggsinformasjon.kt
@@ -1,4 +1,4 @@
-package no.nav.dagpenger.journalføring.arena.adapter
+package no.nav.dagpenger.journalføring.ferdigstill.adapter
 
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/CallIdInterceptor.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/CallIdInterceptor.kt
@@ -1,0 +1,33 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.soap
+
+import de.huxhorn.sulky.ulid.ULID
+import org.apache.cxf.binding.soap.SoapHeader
+import org.apache.cxf.binding.soap.SoapMessage
+import org.apache.cxf.interceptor.Fault
+import org.apache.cxf.jaxb.JAXBDataBinding
+import org.apache.cxf.message.Message
+import org.apache.cxf.phase.AbstractPhaseInterceptor
+import org.apache.cxf.phase.Phase
+import org.slf4j.LoggerFactory
+import javax.xml.bind.JAXBException
+import javax.xml.namespace.QName
+
+private val log = LoggerFactory.getLogger(CallIdInterceptor::class.java)
+private val ulid = ULID()
+
+class CallIdInterceptor : AbstractPhaseInterceptor<Message>(Phase.PRE_STREAM) {
+
+    @Throws(Fault::class)
+    override fun handleMessage(message: Message) {
+        when (message) {
+            is SoapMessage ->
+                try {
+                    val qName = QName("uri:no.nav.applikasjonsrammeverk", "callId")
+                    val header = SoapHeader(qName, ulid.nextULID(), JAXBDataBinding(String::class.java))
+                    message.headers.add(header)
+                } catch (ex: JAXBException) {
+                    log.warn("Error while setting CallId header", ex)
+                }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/STSClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/STSClient.kt
@@ -1,6 +1,5 @@
-package no.nav.dagpenger.journalføring.arena.adapter.soap
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.soap
 
-import no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.CallIdInterceptor
 import org.apache.cxf.Bus
 import org.apache.cxf.BusFactory
 import org.apache.cxf.binding.soap.Soap12

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/STSClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/STSClient.kt
@@ -1,0 +1,70 @@
+package no.nav.dagpenger.journalføring.arena.adapter.soap
+
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.CallIdInterceptor
+import org.apache.cxf.Bus
+import org.apache.cxf.BusFactory
+import org.apache.cxf.binding.soap.Soap12
+import org.apache.cxf.binding.soap.SoapMessage
+import org.apache.cxf.endpoint.Client
+import org.apache.cxf.frontend.ClientProxy
+import org.apache.cxf.ws.policy.PolicyBuilder
+import org.apache.cxf.ws.policy.PolicyEngine
+import org.apache.cxf.ws.policy.attachment.reference.RemoteReferenceResolver
+import org.apache.cxf.ws.security.SecurityConstants
+import org.apache.cxf.ws.security.trust.STSClient
+import org.apache.neethi.Policy
+
+const val STS_CLIENT_AUTHENTICATION_POLICY = "classpath:policy/untPolicy.xml"
+const val STS_SAML_POLICY = "classpath:policy/requestSamlPolicy.xml"
+const val STS_SAML_POLICY_NO_TRANSPORT_BINDING = "classpath:policy/requestSamlPolicyNoTransportBinding.xml"
+
+fun stsClient(stsUrl: String, credentials: Pair<String, String>): STSClient {
+    val bus = BusFactory.getDefaultBus()
+    return STSClient(bus).apply {
+        isEnableAppliesTo = false
+        isAllowRenewing = false
+
+        location = stsUrl
+        outInterceptors = listOf(CallIdInterceptor())
+
+        properties = mapOf(
+            SecurityConstants.USERNAME to credentials.first,
+            SecurityConstants.PASSWORD to credentials.second
+        )
+
+        setPolicy(bus.resolvePolicy(STS_CLIENT_AUTHENTICATION_POLICY))
+    }
+}
+
+fun STSClient.configureFor(servicePort: Any) {
+    configureFor(servicePort, STS_SAML_POLICY)
+}
+
+fun STSClient.configureFor(servicePort: Any, policyUri: String) {
+    val client = ClientProxy.getClient(servicePort)
+    client.configureSTS(this, policyUri)
+}
+
+fun Client.configureSTS(stsClient: STSClient, policyUri: String = STS_SAML_POLICY) {
+    requestContext[SecurityConstants.STS_CLIENT] = stsClient
+    requestContext[SecurityConstants.CACHE_ISSUED_TOKEN_IN_ENDPOINT] = true
+
+    setClientEndpointPolicy(bus.resolvePolicy(policyUri))
+}
+
+private fun Bus.resolvePolicy(policyUri: String): Policy {
+    val registry = getExtension(PolicyEngine::class.java).registry
+    val resolved = registry.lookup(policyUri)
+
+    val policyBuilder = getExtension(PolicyBuilder::class.java)
+    val referenceResolver = RemoteReferenceResolver("", policyBuilder)
+
+    return resolved ?: referenceResolver.resolveReference(policyUri)
+}
+
+private fun Client.setClientEndpointPolicy(policy: Policy) {
+    val policyEngine: PolicyEngine = bus.getExtension(PolicyEngine::class.java)
+    val message = SoapMessage(Soap12.getInstance())
+    val endpointPolicy = policyEngine.getClientEndpointPolicy(endpoint.endpointInfo, null, message)
+    policyEngine.setClientEndpointPolicy(endpoint.endpointInfo, endpointPolicy.updatePolicy(policy, message))
+}

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/SoapPort.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/SoapPort.kt
@@ -1,7 +1,6 @@
-package no.nav.dagpenger.journalføring.arena.adapter.soap
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.soap
 
 import no.nav.cxf.metrics.MetricFeature
-import no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.CallIdInterceptor
 import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.BehandleArbeidOgAktivitetOppgaveV1
 import no.nav.tjeneste.virksomhet.ytelseskontrakt.v3.YtelseskontraktV3
 import org.apache.cxf.jaxws.JaxWsProxyFactoryBean

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/SoapPort.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/SoapPort.kt
@@ -1,0 +1,56 @@
+package no.nav.dagpenger.journalføring.arena.adapter.soap
+
+import no.nav.cxf.metrics.MetricFeature
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.CallIdInterceptor
+import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.BehandleArbeidOgAktivitetOppgaveV1
+import no.nav.tjeneste.virksomhet.ytelseskontrakt.v3.YtelseskontraktV3
+import org.apache.cxf.jaxws.JaxWsProxyFactoryBean
+import org.apache.cxf.ws.addressing.WSAddressingFeature
+import javax.xml.namespace.QName
+
+object SoapPort {
+
+    fun ytelseskontraktV3(serviceUrl: String): YtelseskontraktV3 {
+        return createServicePort(
+            serviceUrl = serviceUrl,
+            serviceClazz = YtelseskontraktV3::class.java,
+            wsdl = "wsdl/tjenestespesifikasjon/no/nav/tjeneste/virksomhet/ytelseskontrakt/v3/Binding.wsdl",
+            namespace = "http://nav.no/tjeneste/virksomhet/ytelseskontrakt/v3/Binding",
+            svcName = "Ytelseskontrakt_v3",
+            portName = "Ytelseskontrakt_v3Port"
+        )
+    }
+
+    fun behandleArbeidOgAktivitetOppgaveV1(serviceUrl: String): BehandleArbeidOgAktivitetOppgaveV1 {
+
+        return createServicePort(
+            serviceUrl = serviceUrl,
+            serviceClazz = BehandleArbeidOgAktivitetOppgaveV1::class.java,
+            wsdl = "wsdl/no/nav/tjeneste/virksomhet/behandleArbeidOgAktivitetOppgave/v1/Binding.wsdl",
+            namespace = "http://nav.no/tjeneste/virksomhet/behandleArbeidOgAktivitetOppgave/v1/Binding",
+            svcName = "BehandleArbeidOgAktivitetOppgave_v1",
+            portName = "BehandleArbeidOgAktivitetOppgave_v1Port"
+        )
+    }
+
+    private fun <PORT_TYPE> createServicePort(
+        serviceUrl: String,
+        serviceClazz: Class<PORT_TYPE>,
+        wsdl: String,
+        namespace: String,
+        svcName: String,
+        portName: String
+    ): PORT_TYPE {
+        val factory = JaxWsProxyFactoryBean().apply {
+            address = serviceUrl
+            wsdlURL = wsdl
+            serviceName = QName(namespace, svcName)
+            endpointName = QName(namespace, portName)
+            serviceClass = serviceClazz
+            features = listOf(WSAddressingFeature(), MetricFeature())
+            outInterceptors.add(CallIdInterceptor())
+        }
+
+        return factory.create(serviceClazz)
+    }
+}

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/arena/SoapArenaClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/arena/SoapArenaClient.kt
@@ -1,0 +1,83 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.arena
+
+import no.nav.dagpenger.journalføring.arena.adapter.ArenaClient
+import no.nav.dagpenger.journalføring.arena.adapter.ArenaSak
+import no.nav.dagpenger.journalføring.arena.adapter.ArenaSakStatus
+import no.nav.dagpenger.journalføring.arena.adapter.BestillOppgaveArenaException
+import no.nav.dagpenger.journalføring.arena.adapter.HentArenaSakerException
+import no.nav.dagpenger.streams.HealthStatus
+import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.BehandleArbeidOgAktivitetOppgaveV1
+import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.informasjon.WSOppgave
+import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.informasjon.WSOppgavetype
+import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.informasjon.WSPerson
+import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.informasjon.WSPrioritet
+import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.informasjon.WSSakInfo
+import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.informasjon.WSTema
+import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.meldinger.WSBestillOppgaveRequest
+import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.meldinger.WSBestillOppgaveResponse
+import no.nav.tjeneste.virksomhet.ytelseskontrakt.v3.YtelseskontraktV3
+import no.nav.tjeneste.virksomhet.ytelseskontrakt.v3.meldinger.WSHentYtelseskontraktListeRequest
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.GregorianCalendar
+import javax.xml.datatype.DatatypeFactory
+
+class SoapArenaClient(private val oppgaveV1: BehandleArbeidOgAktivitetOppgaveV1, private val ytelseskontraktV3: YtelseskontraktV3) : ArenaClient {
+
+    override fun bestillOppgave(naturligIdent: String, behandlendeEnhetId: String, tilleggsinformasjon: String): String {
+        val soapRequest = WSBestillOppgaveRequest()
+
+        soapRequest.oppgavetype = WSOppgavetype().apply { value = "STARTVEDTAK" }
+
+        val today = ZonedDateTime.now().toInstant().atZone(ZoneId.of("Europe/Oslo"))
+
+        soapRequest.oppgave = WSOppgave().apply {
+            tema = WSTema().apply { value = "DAG" }
+            bruker = WSPerson().apply { ident = naturligIdent }
+            this.behandlendeEnhetId = behandlendeEnhetId
+            prioritet = WSPrioritet().apply {
+                this.value = "HOY"
+            }
+            frist = DatatypeFactory.newInstance().newXMLGregorianCalendar(GregorianCalendar.from(today))
+            sakInfo = WSSakInfo().withTvingNySak(true)
+            beskrivelse = "Start Vedtaksbehandling - automatisk journalført.\n"
+            this.tilleggsinformasjon = tilleggsinformasjon
+        }
+
+        val response: WSBestillOppgaveResponse = try {
+            oppgaveV1.bestillOppgave(soapRequest)
+        } catch (e: Exception) {
+            throw BestillOppgaveArenaException(e)
+            // @todo Håndtere BestillOppgaveSikkerhetsbegrensning, BestillOppgaveOrganisasjonIkkeFunnet, BestillOppgavePersonErInaktiv, BestillOppgaveSakIkkeOpprettet, BestillOppgavePersonIkkeFunnet, BestillOppgaveUgyldigInput
+        }
+
+        return response.arenaSakId
+    }
+
+    override fun hentArenaSaker(naturligIdent: String): List<ArenaSak> {
+        val request =
+            WSHentYtelseskontraktListeRequest()
+                .withPersonidentifikator(naturligIdent)
+
+        try {
+            val response = ytelseskontraktV3.hentYtelseskontraktListe(request)
+            return response.ytelseskontraktListe.filter { it.ytelsestype == "Dagpenger" }.map {
+                ArenaSak(
+                    it.fagsystemSakId,
+                    ArenaSakStatus.valueOf(it.status)
+                )
+            }
+        } catch (e: Exception) {
+            throw HentArenaSakerException(e)
+        }
+    }
+
+    override fun status(): HealthStatus {
+        return try {
+            ytelseskontraktV3.ping()
+            HealthStatus.UP
+        } catch (e: Exception) {
+            HealthStatus.DOWN
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/arena/SoapArenaClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/arena/SoapArenaClient.kt
@@ -1,10 +1,10 @@
 package no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.arena
 
-import no.nav.dagpenger.journalføring.arena.adapter.ArenaClient
-import no.nav.dagpenger.journalføring.arena.adapter.ArenaSak
-import no.nav.dagpenger.journalføring.arena.adapter.ArenaSakStatus
-import no.nav.dagpenger.journalføring.arena.adapter.BestillOppgaveArenaException
-import no.nav.dagpenger.journalføring.arena.adapter.HentArenaSakerException
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaClient
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaSak
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaSakStatus
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.BestillOppgaveArenaException
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.HentArenaSakerException
 import no.nav.dagpenger.streams.HealthStatus
 import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.BehandleArbeidOgAktivitetOppgaveV1
 import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.informasjon.WSOppgave
@@ -22,7 +22,8 @@ import java.time.ZonedDateTime
 import java.util.GregorianCalendar
 import javax.xml.datatype.DatatypeFactory
 
-class SoapArenaClient(private val oppgaveV1: BehandleArbeidOgAktivitetOppgaveV1, private val ytelseskontraktV3: YtelseskontraktV3) : ArenaClient {
+class SoapArenaClient(private val oppgaveV1: BehandleArbeidOgAktivitetOppgaveV1, private val ytelseskontraktV3: YtelseskontraktV3) :
+    ArenaClient {
 
     override fun bestillOppgave(naturligIdent: String, behandlendeEnhetId: String, tilleggsinformasjon: String): String {
         val soapRequest = WSBestillOppgaveRequest()

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/DokumentAdapterTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/DokumentAdapterTest.kt
@@ -1,0 +1,19 @@
+package no.nav.dagpenger.journalføring.ferdigstill
+
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
+import org.junit.jupiter.api.Test
+
+class DokumentAdapterTest {
+    @Test
+    fun `Skal greie å konvertere dokumentInfo med flere felter til Dokument med tittel`() {
+
+        val json = """[{"tittel": "en", "brevkode": "123", "dokumentInfoId": "hallo"}, {"tittel": "to", "dokumentInfoId": "hei"}]""".trimIndent()
+
+        val konverterteDokumenter = dokumentAdapter.fromJson(json)
+
+        konverterteDokumenter shouldNotBe null
+        konverterteDokumenter?.first()?.tittel shouldBe "en"
+        konverterteDokumenter?.last()?.tittel shouldBe "to"
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/FeatureToggleTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/FeatureToggleTest.kt
@@ -3,7 +3,6 @@ package no.nav.dagpenger.journalføring.ferdigstill
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.dagpenger.events.Packet
-import no.nav.dagpenger.journalføring.ferdigstill.PacketKeys.ARENA_SAK_ID
 import org.junit.jupiter.api.Test
 
 internal class FeatureToggleTest {
@@ -15,7 +14,6 @@ internal class FeatureToggleTest {
         val journalFøringFerdigstill = mockk<JournalFøringFerdigstill>(relaxed = true)
 
         val packetWithoutToggle = Packet().apply {
-            this.putValue(ARENA_SAK_ID, "arenaSakid")
         }
 
         Application(configuration, journalFøringFerdigstill).onPacket(packetWithoutToggle)
@@ -25,7 +23,6 @@ internal class FeatureToggleTest {
         }
 
         val packetWithToggleFalse = Packet().apply {
-            this.putValue(ARENA_SAK_ID, "arenaSakid")
             this.putValue("toggleBehandleNySøknad", false)
         }
 
@@ -41,7 +38,6 @@ internal class FeatureToggleTest {
         val journalFøringFerdigstill = mockk<JournalFøringFerdigstill>(relaxed = true)
 
         val packet = Packet().apply {
-            this.putValue(ARENA_SAK_ID, "arenaSakid")
             this.putValue("toggleBehandleNySøknad", true)
         }
 

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalFøringFerdigstillTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalFøringFerdigstillTest.kt
@@ -7,10 +7,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.prometheus.client.CollectorRegistry
 import no.nav.dagpenger.events.Packet
-import no.nav.dagpenger.journalføring.arena.adapter.ArenaClient
-import no.nav.dagpenger.journalføring.arena.adapter.ArenaSak
-import no.nav.dagpenger.journalføring.arena.adapter.ArenaSakStatus
-import no.nav.dagpenger.journalføring.arena.adapter.BestillOppgaveArenaException
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.BestillOppgaveArenaException
 import no.nav.dagpenger.journalføring.ferdigstill.PacketKeys.AKTØR_ID
 import no.nav.dagpenger.journalføring.ferdigstill.PacketKeys.AVSENDER_NAVN
 import no.nav.dagpenger.journalføring.ferdigstill.PacketKeys.BEHANDLENDE_ENHET
@@ -19,6 +16,9 @@ import no.nav.dagpenger.journalføring.ferdigstill.PacketKeys.DOKUMENTER
 import no.nav.dagpenger.journalføring.ferdigstill.PacketKeys.NATURLIG_IDENT
 import no.nav.dagpenger.journalføring.ferdigstill.PacketKeys.JOURNALPOST_ID
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.dokumentJsonAdapter
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaClient
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaSak
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaSakStatus
 import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.BestillOppgavePersonErInaktiv
 import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.BestillOppgavePersonIkkeFunnet
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalPostRestApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalPostRestApiTest.kt
@@ -74,7 +74,7 @@ internal class JournalPostRestApiTest {
 
         val stsOidcClient: StsOidcClient = mockk(relaxed = true)
 
-        val client: OppgaveClient = GosysOppgaveClient(server.baseUrl(), stsOidcClient)
+        val client: ManuellJournalføringsOppgaveClient = GosysOppgaveClient(server.baseUrl(), stsOidcClient)
 
         assertDoesNotThrow {
             client.opprettOppgave(

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillComponentTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillComponentTest.kt
@@ -23,10 +23,10 @@ import no.nav.common.JAASCredential
 import no.nav.common.KafkaEnvironment
 import no.nav.common.embeddedutils.getAvailablePort
 import no.nav.dagpenger.events.Packet
-import no.nav.dagpenger.journalføring.arena.adapter.ArenaClient
 import no.nav.dagpenger.journalføring.ferdigstill.JournalPostRestApi.Companion.toJsonPayload
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.dokumentJsonAdapter
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.journalPostFrom
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaClient
 import no.nav.dagpenger.oidc.StsOidcClient
 import no.nav.dagpenger.streams.KafkaCredential
 import org.apache.kafka.clients.CommonClientConfigs

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillComponentTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillComponentTest.kt
@@ -158,7 +158,7 @@ internal class JournalforingFerdigstillComponentTest {
             dokumentJsonAdapter.toJsonValue(listOf(Dokument("id1", "tittel1"), Dokument("id1", "tittel1")))?.let { this.putValue(PacketKeys.DOKUMENTER, it) }
         }
 
-        val json = journalPostFrom(packet).let { toJsonPayload(it) }
+        val json = journalPostFrom(packet, "arenaSakId").let { toJsonPayload(it) }
 
         behovProducer(configuration).run {
             this.send(ProducerRecord(configuration.kafka.dagpengerJournalpostTopic.name, packet)).get()

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillComponentTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillComponentTest.kt
@@ -16,12 +16,14 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern
 import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.shouldBe
+import io.mockk.every
 import io.mockk.mockk
 import no.finn.unleash.FakeUnleash
 import no.nav.common.JAASCredential
 import no.nav.common.KafkaEnvironment
 import no.nav.common.embeddedutils.getAvailablePort
 import no.nav.dagpenger.events.Packet
+import no.nav.dagpenger.journalføring.arena.adapter.ArenaClient
 import no.nav.dagpenger.journalføring.ferdigstill.JournalPostRestApi.Companion.toJsonPayload
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.dokumentJsonAdapter
 import no.nav.dagpenger.journalføring.ferdigstill.PacketToJoarkPayloadMapper.journalPostFrom
@@ -53,7 +55,7 @@ internal class JournalforingFerdigstillComponentTest {
             topicInfos = listOf(KafkaEnvironment.TopicInfo("privat-dagpenger-journalpost-mottatt-v1"))
         )
 
-        val journalPostApiMock by lazy {
+        val wireMockServer by lazy {
             WireMockServer(wireMockConfig().dynamicPort()).also {
                 it.start()
             }
@@ -68,13 +70,19 @@ internal class JournalforingFerdigstillComponentTest {
                 httpPort = getAvailablePort()
             ),
             sts = Configuration.Sts(
-                baseUrl = journalPostApiMock.baseUrl()
+                baseUrl = wireMockServer.baseUrl()
             ),
-            journalPostApiUrl = journalPostApiMock.baseUrl()
+            journalPostApiUrl = wireMockServer.baseUrl()
         )
 
+        val arenaClientMock: ArenaClient = mockk(relaxed = true)
+
         val stsOidcClient = StsOidcClient(configuration.sts.baseUrl, configuration.sts.username, configuration.sts.password)
-        val journalFøringFerdigstill = JournalFøringFerdigstill(JournalPostRestApi(configuration.journalPostApiUrl, stsOidcClient), mockk(), mockk())
+        val journalFøringFerdigstill = JournalFøringFerdigstill(
+            JournalPostRestApi(configuration.journalPostApiUrl, stsOidcClient),
+            manuellJournalføringsOppgaveClient = mockk(),
+            arenaClient = arenaClientMock)
+
         val unleash = FakeUnleash().apply {
             this.enableAll()
         }
@@ -91,7 +99,7 @@ internal class JournalforingFerdigstillComponentTest {
         @JvmStatic
         fun teardown() {
             embeddedEnvironment.tearDown()
-            journalPostApiMock.stop()
+            wireMockServer.stop()
             app.stop()
         }
     }
@@ -111,13 +119,13 @@ internal class JournalforingFerdigstillComponentTest {
 
     @Test
     fun `Mock journal post API  up and running `() {
-        "${journalPostApiMock.baseUrl()}/__admin".httpGet().response().second.statusCode shouldBe 200
+        "${wireMockServer.baseUrl()}/__admin".httpGet().response().second.statusCode shouldBe 200
     }
 
     @Test
     fun ` Component test of JournalføringFerdigstill`() {
 
-        journalPostApiMock.addStubMapping(
+        wireMockServer.addStubMapping(
             get(urlEqualTo("/rest/v1/sts/token/?grant_type=client_credentials&scope=openid"))
                 .willReturn(okJson("""
                    {
@@ -131,30 +139,34 @@ internal class JournalforingFerdigstillComponentTest {
         )
 
         val journalPostId = "journalPostId"
-        journalPostApiMock.addStubMapping(
+        wireMockServer.addStubMapping(
             patch(urlEqualTo("/rest/journalpostapi/v1/journalpost/$journalPostId/ferdigstill"))
                 .willReturn(aResponse()
                     .withStatus(200))
                 .build()
         )
 
-        journalPostApiMock.addStubMapping(
+        wireMockServer.addStubMapping(
             put(urlEqualTo("/rest/journalpostapi/v1/journalpost/$journalPostId"))
                 .willReturn(aResponse()
                     .withStatus(200))
                 .build()
         )
 
+        every {
+            arenaClientMock.bestillOppgave(naturligIdent = "fnr", behandlendeEnhetId = "9999", tilleggsinformasjon = any())
+        } returns "arenaSakId"
+
         val expectedFerdigstillJson = """{ "journalfoerendeEnhet" : "9999"}"""
 
         val packet = Packet().apply {
-            this.putValue(PacketKeys.ARENA_SAK_OPPRETTET, true)
             this.putValue(PacketKeys.NATURLIG_IDENT, "fnr")
+            this.putValue(PacketKeys.AKTØR_ID, "1234567")
             this.putValue(PacketKeys.JOURNALPOST_ID, journalPostId)
-            this.putValue(PacketKeys.ARENA_SAK_ID, "arenaSakId")
             this.putValue(PacketKeys.AVSENDER_NAVN, "et navn")
             this.putValue(PacketKeys.TOGGLE_BEHANDLE_NY_SØKNAD, true)
             this.putValue(PacketKeys.BEHANDLENDE_ENHET, "9999")
+            this.putValue(PacketKeys.DATO_REGISTRERT, "2020-01-01")
             dokumentJsonAdapter.toJsonValue(listOf(Dokument("id1", "tittel1"), Dokument("id1", "tittel1")))?.let { this.putValue(PacketKeys.DOKUMENTER, it) }
         }
 
@@ -165,12 +177,12 @@ internal class JournalforingFerdigstillComponentTest {
         }
 
         retry {
-            journalPostApiMock.verify(1,
+            wireMockServer.verify(1,
                 putRequestedFor(urlMatching("/rest/journalpostapi/v1/journalpost/$journalPostId"))
                     .withRequestBody(EqualToJsonPattern(json, true, false))
                     .withHeader("Content-Type", equalTo("application/json")).withHeader("Authorization", equalTo("Bearer token")))
 
-            journalPostApiMock.verify(1, patchRequestedFor(urlMatching("/rest/journalpostapi/v1/journalpost/$journalPostId/ferdigstill"))
+            wireMockServer.verify(1, patchRequestedFor(urlMatching("/rest/journalpostapi/v1/journalpost/$journalPostId/ferdigstill"))
                 .withRequestBody(EqualToJsonPattern(expectedFerdigstillJson, true, false))
                 .withHeader("Content-Type", equalTo("application/json")).withHeader("Authorization", equalTo("Bearer token")))
         }

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillComponentTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillComponentTest.kt
@@ -74,7 +74,7 @@ internal class JournalforingFerdigstillComponentTest {
         )
 
         val stsOidcClient = StsOidcClient(configuration.sts.baseUrl, configuration.sts.username, configuration.sts.password)
-        val journalFøringFerdigstill = JournalFøringFerdigstill(JournalPostRestApi(configuration.journalPostApiUrl, stsOidcClient), mockk())
+        val journalFøringFerdigstill = JournalFøringFerdigstill(JournalPostRestApi(configuration.journalPostApiUrl, stsOidcClient), mockk(), mockk())
         val unleash = FakeUnleash().apply {
             this.enableAll()
         }
@@ -149,7 +149,7 @@ internal class JournalforingFerdigstillComponentTest {
 
         val packet = Packet().apply {
             this.putValue(PacketKeys.ARENA_SAK_OPPRETTET, true)
-            this.putValue(PacketKeys.FNR, "fnr")
+            this.putValue(PacketKeys.NATURLIG_IDENT, "fnr")
             this.putValue(PacketKeys.JOURNALPOST_ID, journalPostId)
             this.putValue(PacketKeys.ARENA_SAK_ID, "arenaSakId")
             this.putValue(PacketKeys.AVSENDER_NAVN, "et navn")

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketToJoarkPayloadMapperTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketToJoarkPayloadMapperTest.kt
@@ -87,7 +87,6 @@ internal class PacketToJoarkPayloadMapperTest {
         jp.bruker.idType shouldBe "FNR"
         jp.dokumenter shouldBe listOf(Dokument("dokumentId", "tittel"))
         jp.journalfoerendeEnhet shouldBe "9999"
-        jp.sak.saksType shouldBe SaksType.GENERELL_SAK
         jp.tema shouldBe "DAG"
         jp.tittel shouldBe "tittel"
     }

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketToJoarkPayloadMapperTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketToJoarkPayloadMapperTest.kt
@@ -24,7 +24,7 @@ internal class PacketToJoarkPayloadMapperTest {
     @Test
     fun `Exctract bruker from packet`() {
         PacketToJoarkPayloadMapper.brukerFrom(Packet().apply {
-            this.putValue(PacketKeys.FNR, "fnr")
+            this.putValue(PacketKeys.NATURLIG_IDENT, "fnr")
         }).id shouldBe "fnr"
     }
 
@@ -73,7 +73,7 @@ internal class PacketToJoarkPayloadMapperTest {
         val jp = PacketToJoarkPayloadMapper.journalPostFrom(Packet().apply {
             this.putValue(PacketKeys.JOURNALPOST_ID, "journalPostId")
             this.putValue(PacketKeys.AVSENDER_NAVN, "navn")
-            this.putValue(PacketKeys.FNR, "fnr")
+            this.putValue(PacketKeys.NATURLIG_IDENT, "fnr")
             dokumentJsonAdapter.toJsonValue(listOf(Dokument("dokumentId", "tittel")))?.let { this.putValue(PacketKeys.DOKUMENTER, it) }
         })
 

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketToJoarkPayloadMapperTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketToJoarkPayloadMapperTest.kt
@@ -29,26 +29,6 @@ internal class PacketToJoarkPayloadMapperTest {
     }
 
     @Test
-    fun `Exctract Arena sak from packet`() {
-        val sak = PacketToJoarkPayloadMapper.sakFrom(Packet().apply {
-            this.putValue(PacketKeys.ARENA_SAK_ID, "sakId")
-        })
-
-        sak.fagsakId shouldBe "sakId"
-        sak.saksType shouldBe SaksType.FAGSAK
-        sak.fagsaksystem shouldBe "AO01"
-    }
-
-    @Test
-    fun `Exctract Generell sak from packet`() {
-        val sak = PacketToJoarkPayloadMapper.sakFrom(Packet())
-
-        sak.saksType shouldBe SaksType.GENERELL_SAK
-        sak.fagsaksystem shouldBe null
-        sak.fagsakId shouldBe null
-    }
-
-    @Test
     fun `Extract dokumenter from packet`() {
         val dokumenter = PacketToJoarkPayloadMapper.dokumenterFrom(Packet().apply {
             dokumentJsonAdapter.toJsonValue(listOf(Dokument("id1", "tittel1"), Dokument("id2", "tittel2")))?.let {

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketToJoarkPayloadMapperTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketToJoarkPayloadMapperTest.kt
@@ -70,12 +70,16 @@ internal class PacketToJoarkPayloadMapperTest {
 
     @Test
     fun `Extract journal post from packet`() {
-        val jp = PacketToJoarkPayloadMapper.journalPostFrom(Packet().apply {
-            this.putValue(PacketKeys.JOURNALPOST_ID, "journalPostId")
-            this.putValue(PacketKeys.AVSENDER_NAVN, "navn")
-            this.putValue(PacketKeys.NATURLIG_IDENT, "fnr")
-            dokumentJsonAdapter.toJsonValue(listOf(Dokument("dokumentId", "tittel")))?.let { this.putValue(PacketKeys.DOKUMENTER, it) }
-        })
+        val jp = PacketToJoarkPayloadMapper.journalPostFrom(
+            Packet().apply {
+                this.putValue(PacketKeys.JOURNALPOST_ID, "journalPostId")
+                this.putValue(PacketKeys.AVSENDER_NAVN, "navn")
+                this.putValue(PacketKeys.NATURLIG_IDENT, "fnr")
+                dokumentJsonAdapter.toJsonValue(listOf(Dokument("dokumentId", "tittel")))
+                    ?.let { this.putValue(PacketKeys.DOKUMENTER, it) }
+            },
+            "bla"
+        )
 
         jp.avsenderMottaker.navn shouldBe "navn"
         jp.behandlingstema shouldBe "ab0001"

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaTilleggsinformasjonTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaTilleggsinformasjonTest.kt
@@ -1,0 +1,46 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter
+
+import no.nav.dagpenger.journalføring.arena.adapter.createArenaTilleggsinformasjon
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class ArenaTilleggsinformasjonTest {
+    @Test
+    fun `lager riktig tilleggsinformasjon når den får hoveddokument og vedlegg`() {
+        val tilleggsinformasjon =
+            createArenaTilleggsinformasjon(listOf("Søknad", "Vedlegg: Arbeidsavtale"), "2019-12-24T12:01:57")
+
+        assertEquals(
+            "Hoveddokument: Søknad\n" +
+                "- Vedlegg: Arbeidsavtale\n" +
+                "Registrert dato: 24.12.2019\n" +
+                "Dokumentet er skannet inn og journalført automatisk av digitale dagpenger. " +
+                "Gjennomfør rutinen \"Etterkontroll av automatisk journalførte dokumenter\".", tilleggsinformasjon
+        )
+    }
+
+    @Test
+    fun `formaterer riktig når vedlegg mangler`() {
+        val tilleggsinformasjon =
+            createArenaTilleggsinformasjon(listOf("Søknad"), "2019-12-24T12:01:57")
+
+        assertEquals(
+            "Hoveddokument: Søknad\n" +
+                "Registrert dato: 24.12.2019\n" +
+                "Dokumentet er skannet inn og journalført automatisk av digitale dagpenger. " +
+                "Gjennomfør rutinen \"Etterkontroll av automatisk journalførte dokumenter\".", tilleggsinformasjon
+        )
+    }
+
+    @Test
+    fun `legger ikke til dato hvis den ikke er formatert etter ISO-standard`() {
+        val tilleggsinformasjon =
+            createArenaTilleggsinformasjon(listOf("Søknad"), "2019.12.24")
+
+        assertEquals(
+            "Hoveddokument: Søknad\n" +
+                "Dokumentet er skannet inn og journalført automatisk av digitale dagpenger. " +
+                "Gjennomfør rutinen \"Etterkontroll av automatisk journalførte dokumenter\".", tilleggsinformasjon
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaTilleggsinformasjonTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/ArenaTilleggsinformasjonTest.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.journalføring.ferdigstill.adapter
 
-import no.nav.dagpenger.journalføring.arena.adapter.createArenaTilleggsinformasjon
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/arena/SoapArenaClientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/arena/SoapArenaClientTest.kt
@@ -1,0 +1,85 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.arena
+
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.dagpenger.journalføring.arena.adapter.ArenaSakStatus
+import no.nav.dagpenger.journalføring.arena.adapter.HentArenaSakerException
+import no.nav.dagpenger.streams.HealthStatus
+import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.BehandleArbeidOgAktivitetOppgaveV1
+import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.meldinger.WSBestillOppgaveResponse
+import no.nav.tjeneste.virksomhet.ytelseskontrakt.v3.YtelseskontraktV3
+import no.nav.tjeneste.virksomhet.ytelseskontrakt.v3.informasjon.ytelseskontrakt.WSDagpengekontrakt
+import no.nav.tjeneste.virksomhet.ytelseskontrakt.v3.meldinger.WSHentYtelseskontraktListeResponse
+import org.junit.jupiter.api.Test
+
+internal class SoapArenaClientTest {
+
+    @Test
+    fun `suksessfull bestillOppgave gir arenaSakId `() {
+        val stubbedClient = mockk<BehandleArbeidOgAktivitetOppgaveV1>()
+        every { stubbedClient.bestillOppgave(any()) } returns WSBestillOppgaveResponse().withArenaSakId("123")
+
+        val client = SoapArenaClient(stubbedClient, mockk())
+
+        val actual = client.bestillOppgave("123456789", "abcbscb", "beskrivelse")
+
+        actual shouldBe "123"
+    }
+
+    @Test
+    fun `Skal kunne hente arena saker basert på bruker id`() {
+
+        val ytelseskontraktV3: YtelseskontraktV3 = mockk()
+
+        every {
+            ytelseskontraktV3.hentYtelseskontraktListe(any())
+        } returns WSHentYtelseskontraktListeResponse().withYtelseskontraktListe(listOf(WSDagpengekontrakt().withFagsystemSakId(123).withStatus("Inaktiv").withYtelsestype("Dagpenger")))
+
+        val client = SoapArenaClient(mockk(), ytelseskontraktV3)
+        val saker = client.hentArenaSaker("1234")
+
+        saker.isEmpty() shouldBe false
+        saker.first().fagsystemSakId shouldBe 123
+        saker.first().status shouldBe ArenaSakStatus.Inaktiv
+    }
+
+    @Test
+    fun `Skal kaste unntak med ukjent saksstatus`() {
+
+        val ytelseskontraktV3: YtelseskontraktV3 = mockk()
+
+        every {
+            ytelseskontraktV3.hentYtelseskontraktListe(any())
+        } returns WSHentYtelseskontraktListeResponse().withYtelseskontraktListe(listOf(WSDagpengekontrakt().withFagsystemSakId(123).withStatus("INAKT").withYtelsestype("Dagpenger")))
+
+        val client = SoapArenaClient(mockk(), ytelseskontraktV3)
+
+        shouldThrow<HentArenaSakerException> {
+            client.hentArenaSaker("1234")
+        }
+    }
+
+    @Test
+    fun ` helsesjekk skal være ok når Arena er oppe`() {
+        val ytelseskontraktV3: YtelseskontraktV3 = mockk()
+        every {
+            ytelseskontraktV3.ping()
+        } returns Unit
+
+        val client = SoapArenaClient(mockk(), ytelseskontraktV3)
+        client.status() shouldBe HealthStatus.UP
+    }
+
+    @Test
+    fun ` helsesjekk skal ikke være ok når Arena nede`() {
+        val ytelseskontraktV3: YtelseskontraktV3 = mockk()
+        every {
+            ytelseskontraktV3.ping()
+        } throws RuntimeException()
+
+        val client = SoapArenaClient(mockk(), ytelseskontraktV3)
+        client.status() shouldBe HealthStatus.DOWN
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/arena/SoapArenaClientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/arena/SoapArenaClientTest.kt
@@ -4,8 +4,8 @@ import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.dagpenger.journalføring.arena.adapter.ArenaSakStatus
-import no.nav.dagpenger.journalføring.arena.adapter.HentArenaSakerException
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaSakStatus
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.HentArenaSakerException
 import no.nav.dagpenger.streams.HealthStatus
 import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.BehandleArbeidOgAktivitetOppgaveV1
 import no.nav.tjeneste.virksomhet.behandlearbeidogaktivitetoppgave.v1.meldinger.WSBestillOppgaveResponse


### PR DESCRIPTION
Etter å ha sett på problemet med ukjent bruker, så vi at det begynte å bli veldig mange avhengigheter mellom jrnf-arena og jrnf-ferdigstill.
Derfor prøvde vi oss på å slå de sammen. 
Vi tegnet opp et flytdiagram over det som skjer i innløpet, og så fort at det var en litt rar oppdeling vi hadde før.