### PR TITLE
Feature/evaluate minsteinntekt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,6 @@ dependencies {
     implementation(Moshi.moshi)
     implementation(Moshi.moshiKotlin)
     implementation(Moshi.moshiAdapters)
-    implementation(Moshi.moshiKtor)
     implementation(Prometheus.common)
     implementation(Prometheus.hotspot)
     implementation(Prometheus.log4j2)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,10 +56,14 @@ dependencies {
         }
     }
     implementation(Dagpenger.Streams)
+
+    implementation(Fuel.fuelMoshi)
+
     implementation(Kotlin.Logging.kotlinLogging)
     implementation(Moshi.moshi)
     implementation(Moshi.moshiKotlin)
     implementation(Moshi.moshiAdapters)
+    implementation(Moshi.moshiKtor)
     implementation(Prometheus.common)
     implementation(Prometheus.hotspot)
     implementation(Prometheus.log4j2)

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Application.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Application.kt
@@ -1,6 +1,8 @@
 package no.nav.dagpenger.journalføring.ferdigstill
 
 import mu.KotlinLogging
+import no.finn.unleash.DefaultUnleash
+import no.finn.unleash.Unleash
 import no.nav.dagpenger.events.Packet
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaClient
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.GosysOppgaveClient
@@ -10,6 +12,7 @@ import no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.SoapPort
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.arena.SoapArenaClient
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.configureFor
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.soap.stsClient
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester.Vilkårtester
 import no.nav.dagpenger.oidc.StsOidcClient
 import no.nav.dagpenger.streams.River
 import no.nav.dagpenger.streams.streamConfig
@@ -89,6 +92,9 @@ fun main() {
         soapStsClient.configureFor(ytelseskontraktV3)
     }
 
+    val unleash: Unleash = DefaultUnleash(configuration.application.unleashConfig)
+
+    val vilkårtester = Vilkårtester(configuration.application.regelApiBaseUrl, configuration.auth.regelApiKey)
     val journalFøringFerdigstill = JournalføringFerdigstill(
         JournalpostRestApi(
             configuration.journalPostApiUrl,
@@ -98,7 +104,9 @@ fun main() {
             configuration.gosysApiUrl,
             stsOidcClient
         ),
-        arenaClient
+        arenaClient,
+        vilkårtester,
+        unleash
     )
 
     Application(configuration, journalFøringFerdigstill).start()

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Configuration.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Configuration.kt
@@ -9,29 +9,38 @@ import com.natpryce.konfig.booleanType
 import com.natpryce.konfig.intType
 import com.natpryce.konfig.overriding
 import com.natpryce.konfig.stringType
+import io.netty.util.NetUtil.getHostname
+import no.finn.unleash.util.UnleashConfig
 import no.nav.dagpenger.events.Packet
+import no.nav.dagpenger.ktor.auth.ApiKeyVerifier
 import no.nav.dagpenger.streams.KafkaCredential
 import no.nav.dagpenger.streams.PacketDeserializer
 import no.nav.dagpenger.streams.PacketSerializer
 import no.nav.dagpenger.streams.Topic
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.streams.StreamsConfig
+import java.net.InetAddress
+import java.net.UnknownHostException
 
 private val localProperties = ConfigurationMap(
     mapOf(
         "application.httpPort" to "8080",
         "application.name" to "dagpenger-journalføring-ferdigstill",
         "application.profile" to Profile.LOCAL.toString(),
+        "dp.regel.api.url" to "http://localhost:666",
         "allow.insecure.soap.requests" to false.toString(),
         "journalPostApi.url" to "http://localhost",
         "gosysApi.url" to "http://localhost",
         "kafka.bootstrap.servers" to "localhost:9092",
+        "regel.api.secret" to "secret",
+        "regel.api.key" to "regelKey",
         "srvdagpenger.journalforing.ferdigstill.password" to "password",
         "srvdagpenger.journalforing.ferdigstill.username" to "user",
         "sts.url" to "http://localhost",
         "soapsecuritytokenservice.url" to "http://localhost",
         "behandlearbeidsytelsesak.v1.url" to "https://localhost/ail_ws/BehandleArbeidOgAktivitetOppgave_v1",
         "ytelseskontrakt.v3.url" to "https://localhost/ail_ws/Ytelseskontrakt_v3",
+        "unleash.url" to "http://localhost:1010",
         "kafka.processing.guarantee" to StreamsConfig.AT_LEAST_ONCE
 
     )
@@ -42,6 +51,7 @@ private val devProperties = ConfigurationMap(
         "application.name" to "dagpenger-journalføring-ferdigstill",
         "application.profile" to Profile.DEV.toString(),
         "allow.insecure.soap.requests" to true.toString(),
+        "dp.regel.api.url" to "http://dp-regel-api",
         "journalPostApi.url" to "http://dokarkiv.q1.svc.nais.local",
         "gosysApi.url" to "http://oppgave.default.svc.nais.local",
         "kafka.bootstrap.servers" to "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443",
@@ -49,6 +59,7 @@ private val devProperties = ConfigurationMap(
         "soapsecuritytokenservice.url" to "https://sts-q1.preprod.local/SecurityTokenServiceProvider/",
         "behandlearbeidsytelsesak.v1.url" to "https://arena-q1.adeo.no/ail_ws/BehandleArbeidOgAktivitetOppgave_v1",
         "ytelseskontrakt.v3.url" to "https://arena-q1.adeo.no/ail_ws/Ytelseskontrakt_v3",
+        "unleash.url" to "http://unleash.default.svc.nais.local/api",
         "kafka.processing.guarantee" to StreamsConfig.AT_LEAST_ONCE
     )
 )
@@ -58,6 +69,7 @@ private val prodProperties = ConfigurationMap(
         "application.name" to "dagpenger-journalføring-ferdigstill",
         "application.profile" to Profile.PROD.toString(),
         "allow.insecure.soap.requests" to true.toString(),
+        "dp.regel.api.url" to "http://dp-regel-api",
         "journalPostApi.url" to "http://dokarkiv.default.svc.nais.local",
         "gosysApi.url" to "http://oppgave.default.svc.nais.local",
         "kafka.bootstrap.servers" to "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443",
@@ -65,6 +77,7 @@ private val prodProperties = ConfigurationMap(
         "soapsecuritytokenservice.url" to "https://sts.adeo.no/SecurityTokenServiceProvider/",
         "behandlearbeidsytelsesak.v1.url" to "https://arena.adeo.no/ail_ws/BehandleArbeidOgAktivitetOppgave_v1",
         "ytelseskontrakt.v3.url" to "https://arena.adeo.no/ail_ws/Ytelseskontrakt_v3",
+        "unleash.url" to "https://unleash.nais.adeo.no/api/",
         "kafka.processing.guarantee" to StreamsConfig.EXACTLY_ONCE
     )
 )
@@ -82,6 +95,7 @@ fun config(): Configuration {
 }
 
 data class Configuration(
+    val auth: Auth = Auth(),
     val kafka: Kafka = Kafka(),
     val application: Application = Application(),
     val journalPostApiUrl: String = config()[Key("journalPostApi.url", stringType)],
@@ -91,6 +105,12 @@ data class Configuration(
     val soapSTSClient: SoapSTSClient = SoapSTSClient(),
     val sts: Sts = Sts()
 ) {
+    class Auth(
+        regelApiSecret: String = config()[Key("regel.api.secret", stringType)],
+        regelApiKeyPlain: String = config()[Key("regel.api.key", stringType)]
+    ) {
+        val regelApiKey = ApiKeyVerifier(regelApiSecret).generate(regelApiKeyPlain)
+    }
 
     data class Kafka(
         val dagpengerJournalpostTopic: Topic<String, Packet> = Topic(
@@ -122,7 +142,13 @@ data class Configuration(
     data class Application(
         val profile: Profile = config()[Key("application.profile", stringType)].let { Profile.valueOf(it) },
         val httpPort: Int = config()[Key("application.httpPort", intType)],
-        val name: String = config()[Key("application.name", stringType)]
+        val name: String = config()[Key("application.name", stringType)],
+        val unleashConfig: UnleashConfig = UnleashConfig.builder()
+            .appName(config().getOrElse(Key("app.name", stringType), "dagpenger-journalforing-ferdigstill"))
+            .instanceId(getHostname())
+            .unleashAPI(config()[Key("unleash.url", stringType)])
+            .build(),
+        val regelApiBaseUrl: String = config()[Key("dp.regel.api.url", stringType)]
     )
 
     data class BehandleArbeidsytelseSakConfig(
@@ -136,4 +162,13 @@ data class Configuration(
 
 enum class Profile {
     LOCAL, DEV, PROD
+}
+
+fun getHostname(): String {
+    return try {
+        val addr: InetAddress = InetAddress.getLocalHost()
+        addr.hostName
+    } catch (e: UnknownHostException) {
+        "unknown"
+    }
 }

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstill.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstill.kt
@@ -2,6 +2,7 @@ package no.nav.dagpenger.journalføring.ferdigstill
 
 import com.squareup.moshi.Types
 import mu.KotlinLogging
+import no.finn.unleash.Unleash
 import no.nav.dagpenger.events.Packet
 import no.nav.dagpenger.events.moshiInstance
 import no.nav.dagpenger.journalføring.ferdigstill.PacketMapper.bruker
@@ -14,6 +15,7 @@ import no.nav.dagpenger.journalføring.ferdigstill.adapter.ManuellJournalføring
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.OppdaterJournalpostPayload
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.Sak
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.SaksType
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester.Vilkårtester
 import org.apache.kafka.streams.kstream.Predicate
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -46,7 +48,8 @@ internal object PacketMapper {
             packet.getStringValue(PacketKeys.AKTØR_ID),
             "AKTØR"
         ) else null
-
+    fun aktørFrom(packet: Packet) = Bruker(packet.getStringValue(PacketKeys.AKTØR_ID),
+        "AKTØR")
     fun henvendelse(packet: Packet): Henvendelse = Henvendelse.fra(packet.getStringValue(PacketKeys.HENVENDELSESTYPE))
     fun harFagsakId(packet: Packet): Boolean = packet.hasField(PacketKeys.FAGSAK_ID)
     fun harIkkeFagsakId(packet: Packet): Boolean = !harFagsakId(packet)
@@ -83,12 +86,16 @@ internal object PacketMapper {
             dokumenter = dokumenterFrom(packet)
         )
     }
+
+    fun hasAktørId(packet: Packet) = packet.hasField(PacketKeys.AKTØR_ID)
 }
 
 internal class JournalføringFerdigstill(
     private val journalPostApi: JournalpostApi,
     private val manuellJournalføringsOppgaveClient: ManuellJournalføringsOppgaveClient,
-    private val arenaClient: ArenaClient
+    private val arenaClient: ArenaClient,
+    private val vilkårtester: Vilkårtester,
+    private val unleash: Unleash
 ) {
 
     val ferdigBehandlingslenke = MarkerFerdigBehandlingslenke(null)
@@ -98,6 +105,7 @@ internal class JournalføringFerdigstill(
     val oppdaterLenke = OppdaterJournalpostBehandlingslenke(journalPostApi, ferdigstillOppgaveLenke)
     val eksisterendeSakLenke = EksisterendeSaksForholdBehandlingslenke(arenaClient, oppdaterLenke)
     val nySakLenke = NyttSaksforholdBehandlingslenke(arenaClient, eksisterendeSakLenke)
+    val vilkårtestingLenke = OppfyllerMinsteinntektBehandlingsLenke(vilkårtester, unleash, nySakLenke)
 
     fun handlePacket(packet: Packet): Packet {
         try {

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketKeys.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/PacketKeys.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.journalføring.ferdigstill
 
 internal object PacketKeys {
+    const val OPPFYLLER_MINSTEINNTEKT: String = "oppfyllerMinsteinntekt"
     const val FERDIGSTILT_ARENA: String = "ferdigstiltIArena"
     const val AVSENDER_NAVN: String = "avsenderNavn"
     const val JOURNALPOST_ID: String = "journalpostId"

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/BehovClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/BehovClient.kt
@@ -1,25 +1,14 @@
 package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
 
-import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.httpPost
 import com.github.kittinunf.fuel.moshi.responseObject
 import no.nav.dagpenger.events.moshiInstance
-import no.nav.dagpenger.journalføring.ferdigstill.adapter.Bruker
 import java.time.LocalDate
 
-interface Vilkårtester {
-    fun hentSubsumsjonFor(aktørId: String): Subsumsjon
-}
-
-class VilkårtesterClient(private val regelApiUrl: String, private val regelApiKey: String) : Vilkårtester {
+class BehovClient(private val regelApiUrl: String, private val regelApiKey: String) {
     private val jsonAdapter = moshiInstance.adapter(BehovRequest::class.java)
 
-    override fun hentSubsumsjonFor(aktørId: String): Subsumsjon {
-        val behovId = startBehov(aktørId)
-        return Subsumsjon("", null, null, null, null)
-    }
-
-    private fun startBehov(aktørId: String): String {
+    fun startBehov(aktørId: String): String {
         val behovUrl = "$regelApiUrl/behov"
         val json = jsonAdapter.toJson(createBehovRequest(aktørId))
 
@@ -34,20 +23,16 @@ class VilkårtesterClient(private val regelApiUrl: String, private val regelApiK
             }
         return result.fold({
             response.headers["Location"].first()
-
         }, { fuelError ->
             throw RegelApiBehovHttpClientException(
                 "Failed to run behov. Response message ${response.responseMessage}. Error message: ${fuelError.message}"
             )
-
         })
+    }
+
+    private fun createBehovRequest(aktørId: String): BehovRequest {
+        return BehovRequest(aktørId, -12345, LocalDate.now())
     }
 }
 
-internal fun Request.apiKey(apiKey: String) = this.header("X-API-KEY", apiKey)
-
 class RegelApiBehovHttpClientException(override val message: String) : RuntimeException(message)
-
-private fun createBehovRequest(aktørId: String): BehovRequest {
-    return BehovRequest(aktørId, -12345, LocalDate.now())
-}

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/BehovRequest.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/BehovRequest.kt
@@ -1,0 +1,15 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
+
+import java.time.LocalDate
+
+data class BehovRequest(
+    val aktorId: String,
+    val vedtakId: Int,
+    val beregningsdato: LocalDate,
+    val harAvtjentVerneplikt: Boolean? = null,
+    val oppfyllerKravTilFangstOgFisk: Boolean? = null,
+    val bruktInntektsPeriode: LocalDate? = null,
+    val manueltGrunnlag: Int? = null,
+    val antallBarn: Int? = null,
+    val inntektsId: String? = null
+)

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/BehovStatus.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/BehovStatus.kt
@@ -1,0 +1,7 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
+
+enum class BehovStatus {
+    PENDING
+}
+
+data class BehovStatusResponse(val status: BehovStatus)

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/RequestExtensionApiKey.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/RequestExtensionApiKey.kt
@@ -1,0 +1,5 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
+
+import com.github.kittinunf.fuel.core.Request
+
+internal fun Request.apiKey(apiKey: String) = this.header("X-API-KEY", apiKey)

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/SubsumsjonsClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/SubsumsjonsClient.kt
@@ -1,0 +1,30 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
+
+import com.github.kittinunf.fuel.httpGet
+import com.github.kittinunf.fuel.moshi.moshiDeserializerOf
+import no.nav.dagpenger.events.moshiInstance
+
+class SubsumsjonsClient(private val regelApiUrl: String, private val regelApiKey: String) {
+    fun getSubsumsjon(subsumsjonLocation: String): Subsumsjon {
+        val url = "$regelApiUrl$subsumsjonLocation"
+
+        val jsonAdapter = moshiInstance.adapter(Subsumsjon::class.java)
+
+        val (_, response, result) =
+            with(
+                url
+                    .httpGet()
+                    .apiKey(regelApiKey)
+            ) { responseObject(moshiDeserializerOf(jsonAdapter)) }
+
+        return result.fold({
+            it
+        }, { error ->
+            throw RegelApiSubsumsjonHttpClientException(
+                "Failed to fetch subsumsjon. Response message: ${response.responseMessage}. Error message: ${error.message}"
+            )
+        })
+    }
+}
+
+class RegelApiSubsumsjonHttpClientException(override val message: String) : RuntimeException(message)

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/Vilkårtester.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/Vilkårtester.kt
@@ -2,11 +2,11 @@ package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
 
 import kotlinx.coroutines.runBlocking
 
-interface MinsteArbeidsinntektVilkår {
-    fun harBestått(aktørId: String): Boolean?
+interface MinsteArbeidsinntektVilkårTester {
+    fun harBeståttMinsteArbeidsinntektVilkår(aktørId: String): Boolean?
 }
 
-class Vilkårtester(regelApiUrl: String, regelApiKey: String) : MinsteArbeidsinntektVilkår {
+class Vilkårtester(regelApiUrl: String, regelApiKey: String) : MinsteArbeidsinntektVilkårTester {
     private val BehovClient = BehovClient(regelApiUrl = regelApiUrl, regelApiKey = regelApiKey)
     private val statusPollClient = BehovStatusPoller(regelApiUrl = regelApiUrl, regelApiKey = regelApiKey)
     private val subsumsjonsClient = SubsumsjonsClient(regelApiUrl = regelApiUrl, regelApiKey = regelApiKey)
@@ -19,6 +19,6 @@ class Vilkårtester(regelApiUrl: String, regelApiKey: String) : MinsteArbeidsinn
         return subsumsjon
     }
 
-    override fun harBestått(aktørId: String) =
+    override fun harBeståttMinsteArbeidsinntektVilkår(aktørId: String) =
         hentSubsumsjonFor(aktørId).minsteinntektResultat?.oppfyllerMinsteinntekt
 }

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/Vilkårtester.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/Vilkårtester.kt
@@ -1,0 +1,24 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
+
+import kotlinx.coroutines.runBlocking
+
+interface MinsteArbeidsinntektVilkår {
+    fun harBestått(aktørId: String): Boolean?
+}
+
+class Vilkårtester(regelApiUrl: String, regelApiKey: String) : MinsteArbeidsinntektVilkår {
+    private val BehovClient = BehovClient(regelApiUrl = regelApiUrl, regelApiKey = regelApiKey)
+    private val statusPollClient = BehovStatusPoller(regelApiUrl = regelApiUrl, regelApiKey = regelApiKey)
+    private val subsumsjonsClient = SubsumsjonsClient(regelApiUrl = regelApiUrl, regelApiKey = regelApiKey)
+
+    private fun hentSubsumsjonFor(aktørId: String): Subsumsjon {
+        val statusUrl = BehovClient.startBehov(aktørId)
+        val subsumsjonsLocation = runBlocking { statusPollClient.pollStatus(statusUrl) }
+        val subsumsjon = subsumsjonsClient.getSubsumsjon(subsumsjonsLocation)
+
+        return subsumsjon
+    }
+
+    override fun harBestått(aktørId: String) =
+        hentSubsumsjonFor(aktørId).minsteinntektResultat?.oppfyllerMinsteinntekt
+}

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/VilkårtesterClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/VilkårtesterClient.kt
@@ -1,0 +1,53 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
+
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.httpPost
+import com.github.kittinunf.fuel.moshi.responseObject
+import no.nav.dagpenger.events.moshiInstance
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.Bruker
+import java.time.LocalDate
+
+interface Vilkårtester {
+    fun hentSubsumsjonFor(aktørId: String): Subsumsjon
+}
+
+class VilkårtesterClient(private val regelApiUrl: String, private val regelApiKey: String) : Vilkårtester {
+    private val jsonAdapter = moshiInstance.adapter(BehovRequest::class.java)
+
+    override fun hentSubsumsjonFor(aktørId: String): Subsumsjon {
+        val behovId = startBehov(aktørId)
+        return Subsumsjon("", null, null, null, null)
+    }
+
+    private fun startBehov(aktørId: String): String {
+        val behovUrl = "$regelApiUrl/behov"
+        val json = jsonAdapter.toJson(createBehovRequest(aktørId))
+
+        val (_, response, result) =
+            with(
+                behovUrl.httpPost()
+                    .apiKey(regelApiKey)
+                    .header(mapOf("Content-Type" to "application/json"))
+                    .body(json)
+            ) {
+                responseObject<BehovStatusResponse>()
+            }
+        return result.fold({
+            response.headers["Location"].first()
+
+        }, { fuelError ->
+            throw RegelApiBehovHttpClientException(
+                "Failed to run behov. Response message ${response.responseMessage}. Error message: ${fuelError.message}"
+            )
+
+        })
+    }
+}
+
+internal fun Request.apiKey(apiKey: String) = this.header("X-API-KEY", apiKey)
+
+class RegelApiBehovHttpClientException(override val message: String) : RuntimeException(message)
+
+private fun createBehovRequest(aktørId: String): BehovRequest {
+    return BehovRequest(aktørId, -12345, LocalDate.now())
+}

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillComponentTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillComponentTest.kt
@@ -18,6 +18,7 @@ import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import no.finn.unleash.FakeUnleash
 import no.nav.common.JAASCredential
 import no.nav.common.KafkaEnvironment
 import no.nav.common.embeddedutils.getAvailablePort
@@ -87,7 +88,9 @@ internal class JournalforingFerdigstillComponentTest {
                 stsOidcClient
             ),
             manuellJournalføringsOppgaveClient = mockk(relaxed = true),
-            arenaClient = arenaClientMock
+            arenaClient = arenaClientMock,
+            vilkårtester = mockk(),
+            unleash = FakeUnleash()
         )
 
         private val app = Application(configuration, journalFøringFerdigstill)

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillTest.kt
@@ -75,7 +75,7 @@ internal class JournalføringFerdigstillTest {
             arenaClient.harIkkeAktivSak(any())
         } returns true
 
-        JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient).apply {
+        JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient, mockk(), mockk()).apply {
             val generellPacket = Packet().apply {
                 this.putValue(JOURNALPOST_ID, "journalPostId")
                 this.putValue(AVSENDER_NAVN, "et navn")
@@ -120,7 +120,7 @@ internal class JournalføringFerdigstillTest {
     @Test
     fun `Opprett manuell journalføringsoppgave når bruker er ukjent`() {
         val journalFøringFerdigstill =
-            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient)
+            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient, mockk(), mockk())
         val journalPostId = "journalPostId"
         val dato = "2020-01-01T01:01:01"
         val zonedDateTime = LocalDateTime.parse(dato).atZone(ZoneId.of("Europe/Oslo"))
@@ -157,7 +157,7 @@ internal class JournalføringFerdigstillTest {
     @Test
     fun `Opprett fagsak og oppgave, og ferdigstill, når bruker ikke har aktiv fagsak`() {
         val journalFøringFerdigstill =
-            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient)
+            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient, mockk(), mockk())
         val journalPostId = "journalPostId"
         val naturligIdent = "12345678910"
         val behandlendeEnhet = "9999"
@@ -198,30 +198,6 @@ internal class JournalføringFerdigstillTest {
         slot.captured.naturligIdent shouldBe naturligIdent
     }
 
-    /*@Test
-    fun `kun journalføring blir gjort når oppgave er bestilt`() {
-
-        val packet = lagPacket("journalPostId", "12345678910", "9999").apply {
-            this.putValue(PacketKeys.FERDIGSTILT_ARENA, true)
-        }
-
-        val journalFøringFerdigstill =
-            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient)
-
-        journalFøringFerdigstill.behandleHenvendelseAngåendeEksisterendeSaksforhold(
-            packet,
-            VurderHenvendelseAngåendeEksisterendeSaksforholdCommand("", "", "", ZonedDateTime.now(), "")
-        )
-
-        verify(exactly = 0) {
-            arenaClient.bestillOppgave(any())
-        }
-        verify(exactly = 1) {
-            journalPostApi.oppdater(any(), any())
-            journalPostApi.ferdigstill(any())
-        }
-    }*/
-
     @Test
     fun `Opprett oppgave, og ferdigstill, når brevkode er gjenopptak`() {
         testHenvendelseAngåendeEksisterendeSaksforhold("GJENOPPTAK")
@@ -244,7 +220,7 @@ internal class JournalføringFerdigstillTest {
 
     private fun testHenvendelseAngåendeEksisterendeSaksforhold(henvendelsestype: String) {
         val journalFøringFerdigstill =
-            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient)
+            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient, mockk(), mockk())
         val journalPostId = "journalPostId"
         val naturligIdent = "12345678910"
         val behandlendeEnhet = "9999"
@@ -298,7 +274,7 @@ internal class JournalføringFerdigstillTest {
     @Test
     fun `Opprett manuell journalføringsoppgave når bruker har aktiv fagsak`() {
         val journalFøringFerdigstill =
-            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient)
+            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient, mockk(), mockk())
         val journalPostId = "journalPostId"
         val naturligIdent = "12345678910"
         val behandlendeEnhet = "9999"
@@ -333,7 +309,7 @@ internal class JournalføringFerdigstillTest {
     @Test
     fun `Opprett manuell journalføringsoppgave når bestilling av arena-oppgave feiler`() {
         val journalFøringFerdigstill =
-            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient)
+            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient, mockk(), mockk())
         val journalPostId = "journalPostId"
         val naturligIdent = "12345678910"
         val behandlendeEnhet = "9999"

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/KafkaFeilhåndteringTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/KafkaFeilhåndteringTest.kt
@@ -49,7 +49,7 @@ class KafkaFeilhåndteringTest {
     @Test
     fun `skal fortsette der den slapp når noe feiler`() {
         val journalFøringFerdigstill =
-            JournalføringFerdigstill(journalpostApi, manuellJournalføringsOppgaveClient, arenaClient)
+            JournalføringFerdigstill(journalpostApi, manuellJournalføringsOppgaveClient, arenaClient, mockk(), mockk())
         val application = Application(configuration, journalFøringFerdigstill)
 
         val journalPostId = "journalPostId"

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/VilkårtesterTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/VilkårtesterTest.kt
@@ -1,0 +1,81 @@
+package no.nav.dagpenger.journalføring.ferdigstill
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern
+import com.github.tomakehurst.wiremock.matching.EqualToPattern
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.Bruker
+import no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester.VilkårtesterClient
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class VilkårtesterTest {
+
+    companion object {
+        val server: WireMockServer = WireMockServer(WireMockConfiguration.options().dynamicPort())
+
+        @BeforeAll
+        @JvmStatic
+        fun start() {
+            server.start()
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stop() {
+            server.stop()
+        }
+    }
+
+    @BeforeEach
+    fun configure() {
+        WireMock.configureFor(server.port())
+    }
+
+    @Test
+    fun ` Should start behov `() {
+        val aktørId = "001"
+
+        val responseBody = """
+                {
+                        "status" : "PENDING"
+                }
+            """.trimIndent()
+
+        val equalToPattern = EqualToPattern("regelApiKey")
+        WireMock.stubFor(
+            WireMock.post(WireMock.urlEqualTo("//behov"))
+                .withHeader("X-API-KEY", equalToPattern)
+                .willReturn(
+                    WireMock.aResponse()
+                        .withBody(responseBody)
+                        .withHeader("Location", "/behov/status/123")
+                )
+        )
+
+        val client = VilkårtesterClient(server.url(""), equalToPattern.value)
+
+        client.hentSubsumsjonFor(aktørId)
+
+
+        val expectedRequest = """
+                    {
+                        "aktorId": "$aktørId",
+                        "vedtakId": -12345,
+                        "beregningsdato": "${LocalDate.now()}"
+                    }
+                """.trimIndent()
+
+        server.verify(
+            1,
+            WireMock.postRequestedFor(WireMock.urlMatching("//behov"))
+                .withRequestBody(EqualToJsonPattern(expectedRequest, true, false))
+                .withHeader("Content-Type", WireMock.equalTo("application/json"))
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/BehovClientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/BehovClientTest.kt
@@ -1,21 +1,17 @@
-package no.nav.dagpenger.journalføring.ferdigstill
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern
 import com.github.tomakehurst.wiremock.matching.EqualToPattern
-import no.nav.dagpenger.journalføring.ferdigstill.adapter.Bruker
-import no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester.VilkårtesterClient
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
-class VilkårtesterTest {
-
+class BehovClientTest {
     companion object {
         val server: WireMockServer = WireMockServer(WireMockConfiguration.options().dynamicPort())
 
@@ -58,10 +54,9 @@ class VilkårtesterTest {
                 )
         )
 
-        val client = VilkårtesterClient(server.url(""), equalToPattern.value)
+        val client = BehovClient(server.url(""), equalToPattern.value)
 
-        client.hentSubsumsjonFor(aktørId)
-
+        client.startBehov(aktørId)
 
         val expectedRequest = """
                     {

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/BehovStatusPollerTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/BehovStatusPollerTest.kt
@@ -1,0 +1,89 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.matching.EqualToPattern
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class BehovStatusPollerTest {
+    companion object {
+        val server: WireMockServer = WireMockServer(WireMockConfiguration.options().dynamicPort())
+
+        @BeforeAll
+        @JvmStatic
+        fun start() {
+            server.start()
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stop() {
+            server.stop()
+        }
+    }
+
+    @BeforeEach
+    fun configure() {
+        WireMock.configureFor(server.port())
+    }
+
+    @Test
+    fun ` Poller for status frem til den får redirect `() {
+        val pattern = EqualToPattern("regelApiKey")
+
+        WireMock.stubFor(
+            WireMock.get(WireMock.urlEqualTo("//behov/status/123"))
+                .withHeader("X-API-KEY", pattern)
+                .inScenario("Retry Scenario")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(
+                    WireMock.aResponse()
+                        .withBody(responseBody)
+                )
+                .willSetStateTo("First pending")
+        )
+
+        WireMock.stubFor(
+            WireMock.get(WireMock.urlEqualTo("//behov/status/123"))
+                .withHeader("X-API-KEY", pattern)
+                .inScenario("Retry Scenario")
+                .whenScenarioStateIs("First pending")
+                .willReturn(
+                    WireMock.aResponse()
+                        .withBody(responseBody)
+                )
+                .willSetStateTo("Second pending")
+        )
+
+        WireMock.stubFor(
+            WireMock.get(WireMock.urlEqualTo("//behov/status/123"))
+                .withHeader("X-API-KEY", pattern)
+                .inScenario("Retry Scenario")
+                .whenScenarioStateIs("Second pending")
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(303)
+                        .withHeader("Location", "54321")
+                )
+        )
+
+        val client =
+            BehovStatusPoller(regelApiUrl = server.url(""), regelApiKey = pattern.value)
+
+        val response = runBlocking { client.pollStatus("/behov/status/123") }
+        Assertions.assertEquals("54321", response)
+    }
+
+    val responseBody = """
+                {
+                        "status" : "PENDING"
+                }
+            """.trimIndent()
+}

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/DummySubsumsjon.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/DummySubsumsjon.kt
@@ -1,0 +1,12 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
+
+fun dummySubsumsjon(behovId: String = "abc", minsteinntektResultat: MinsteinntektResultat? = null) = Subsumsjon(
+    behovId = behovId,
+    grunnlagResultat = null,
+    minsteinntektResultat = minsteinntektResultat,
+    periodeResultat = null,
+    satsResultat = null
+)
+
+fun dummyMinsteinntekt(oppfyllerMinsteinntekt: Boolean = true) =
+    MinsteinntektResultat("", "", oppfyllerMinsteinntekt, "", emptyList())

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/SubsumsjonsClientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/SubsumsjonsClientTest.kt
@@ -1,0 +1,57 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.matching.EqualToPattern
+import no.nav.dagpenger.events.moshiInstance
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SubsumsjonsClientTest {
+    companion object {
+        val server: WireMockServer = WireMockServer(WireMockConfiguration.options().dynamicPort())
+
+        @BeforeAll
+        @JvmStatic
+        fun start() {
+            server.start()
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stop() {
+            server.stop()
+        }
+    }
+
+    @BeforeEach
+    fun configure() {
+        WireMock.configureFor(server.port())
+    }
+
+    @Test
+    fun `Should get subsumsjon`() {
+        val behovId = "12345"
+        val subsumsjonResponse = moshiInstance.adapter(Subsumsjon::class.java).toJson(dummySubsumsjon(behovId))
+
+        val equalToPattern = EqualToPattern("regelApiKey")
+        WireMock.stubFor(
+            WireMock.get(WireMock.urlEqualTo("//subsumsjon/112233"))
+                .withHeader("X-API-KEY", equalToPattern)
+                .willReturn(
+                    WireMock.aResponse()
+                        .withBody(subsumsjonResponse)
+                )
+        )
+
+        val client = SubsumsjonsClient(server.url(""), equalToPattern.value)
+
+        val subsumsjon = client.getSubsumsjon("/subsumsjon/112233")
+
+        Assertions.assertEquals(behovId, subsumsjon.behovId)
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/VilkårtesterIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/VilkårtesterIntegrationTest.kt
@@ -1,0 +1,114 @@
+package no.nav.dagpenger.journalføring.ferdigstill.adapter.vilkårtester
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern
+import com.github.tomakehurst.wiremock.matching.EqualToPattern
+import io.kotlintest.shouldBe
+import no.nav.dagpenger.events.moshiInstance
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class VilkårtesterIntegrationTest {
+    companion object {
+        val server: WireMockServer = WireMockServer(WireMockConfiguration.options().dynamicPort())
+
+        @BeforeAll
+        @JvmStatic
+        fun start() {
+            server.start()
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stop() {
+            server.stop()
+        }
+    }
+
+    val xApiKey = "regelApiKey"
+
+    @BeforeEach
+    fun configure() {
+        WireMock.configureFor(server.port())
+    }
+
+    @Test
+    fun ` henter bestått minsteinntekt for aktørid`() {
+        val aktørId = "666"
+        val behovId = "123"
+        val behovLocationUrl = "/behov/status/$behovId"
+        val subsumsjonsId = "112233"
+        val subsumsjon = dummySubsumsjon(
+            behovId = behovId,
+            minsteinntektResultat = dummyMinsteinntekt(oppfyllerMinsteinntekt = true)
+        )
+
+        setUpBehovstarterStub(aktørId, behovLocationUrl)
+        setUpBehovPollerStub(subsumsjonsId)
+        setUpSubsumsjonStub(subsumsjonsId, subsumsjon)
+
+        val client = Vilkårtester(server.baseUrl(), xApiKey)
+        val resultat = client.harBestått(aktørId)
+
+        resultat shouldBe subsumsjon.minsteinntektResultat!!.oppfyllerMinsteinntekt
+    }
+
+    private fun setUpSubsumsjonStub(subsumsjonsId: String, subsumsjon: Subsumsjon) {
+        val subsumsjonResponse = moshiInstance.adapter(Subsumsjon::class.java)
+            .toJson(subsumsjon)
+
+        val equalToPattern = EqualToPattern("regelApiKey")
+        WireMock.stubFor(
+            WireMock.get(WireMock.urlEqualTo("/subsumsjon/$subsumsjonsId"))
+                .withHeader("X-API-KEY", equalToPattern)
+                .willReturn(
+                    WireMock.aResponse()
+                        .withBody(subsumsjonResponse)
+                )
+        )
+    }
+
+    private fun setUpBehovPollerStub(subsumsjonsId: String) {
+        WireMock.stubFor(
+            WireMock.get(WireMock.urlEqualTo("/behov/status/123"))
+                .withHeader("X-API-KEY", EqualToPattern(xApiKey))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(303)
+                        .withHeader("Location", "/subsumsjon/$subsumsjonsId")
+                )
+        )
+    }
+
+    private fun setUpBehovstarterStub(aktørId: String, behovLocationUrl: String) {
+        val behovstarterResponse = """
+                {
+                        "status" : "PENDING"
+                }
+            """.trimIndent()
+
+        val expectedRequest = """
+                    {
+                        "aktorId": "$aktørId",
+                        "vedtakId": -12345,
+                        "beregningsdato": "${LocalDate.now()}"
+                    }
+                """.trimIndent()
+
+        WireMock.stubFor(
+            WireMock.post(WireMock.urlEqualTo("/behov"))
+                .withHeader("X-API-KEY", EqualToPattern(xApiKey))
+                .withRequestBody(EqualToJsonPattern(expectedRequest, true, false))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withBody(behovstarterResponse)
+                        .withHeader("Location", behovLocationUrl)
+                )
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/VilkårtesterIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/vilkårtester/VilkårtesterIntegrationTest.kt
@@ -53,7 +53,7 @@ class VilkårtesterIntegrationTest {
         setUpSubsumsjonStub(subsumsjonsId, subsumsjon)
 
         val client = Vilkårtester(server.baseUrl(), xApiKey)
-        val resultat = client.harBestått(aktørId)
+        val resultat = client.harBeståttMinsteArbeidsinntektVilkår(aktørId)
 
         resultat shouldBe subsumsjon.minsteinntektResultat!!.oppfyllerMinsteinntekt
     }

--- a/src/test/resources/test-data/example-subsumsjon-payload.json
+++ b/src/test/resources/test-data/example-subsumsjon-payload.json
@@ -1,0 +1,103 @@
+{
+  "id": "01DBFXH3YD8JQ6ADK6Y7EX4K07",
+  "behovId": "01DBFXH33AAB6MAEK3SRQE5820",
+  "faktum": {
+    "aktorId": "0304060708090",
+    "vedtakId": 123456,
+    "beregningsdato": "2019-05-08",
+    "inntektsId": "01DBFXH3KBYX5YRV18CRM2NFHY",
+    "inntektAvvik": false,
+    "inntektManueltRedigert": false,
+    "antallBarn": 0
+  },
+  "grunnlagResultat": {
+    "avkortet": "150000",
+    "uavkortet": "150000",
+    "sporingsId": "01DBFXH3PB8DXWJHB8G2YJ9E2W",
+    "harAvkortet": false,
+    "subsumsjonsId": "01DBFXH3PBT5MSBEB9RN3WQRMS",
+    "beregningsregel": "ArbeidsinntektSiste12",
+    "regelIdentifikator": "Grunnlag.v1",
+    "grunnlagInntektsPerioder": [
+      {
+        "inntekt": "150000",
+        "periode": 1,
+        "inntektsPeriode": {
+          "sisteMåned": "2019-04",
+          "førsteMåned": "2018-05"
+        },
+        "inneholderFangstOgFisk": false
+      },
+      {
+        "inntekt": "0",
+        "periode": 2,
+        "inntektsPeriode": {
+          "sisteMåned": "2018-04",
+          "førsteMåned": "2017-05"
+        },
+        "inneholderFangstOgFisk": false
+      },
+      {
+        "inntekt": "0",
+        "periode": 3,
+        "inntektsPeriode": {
+          "sisteMåned": "2017-04",
+          "førsteMåned": "2016-05"
+        },
+        "inneholderFangstOgFisk": false
+      }
+    ]
+  },
+  "minsteinntektResultat": {
+    "sporingsId": "01DBFXH3N13T7RAF8R17WQHPWZ",
+    "subsumsjonsId": "01DBFXH3N1BSSVXB6X0GVFV7X3",
+    "regelIdentifikator": "Minsteinntekt.v1",
+    "oppfyllerMinsteinntekt": true,
+    "minsteinntektInntektsPerioder": [
+      {
+        "andel": "150000",
+        "inntekt": "150000",
+        "periode": 1,
+        "inntektsPeriode": {
+          "sisteMåned": "2019-04",
+          "førsteMåned": "2018-05"
+        },
+        "inneholderFangstOgFisk": false
+      },
+      {
+        "andel": "0",
+        "inntekt": "0",
+        "periode": 2,
+        "inntektsPeriode": {
+          "sisteMåned": "2018-04",
+          "førsteMåned": "2017-05"
+        },
+        "inneholderFangstOgFisk": false
+      },
+      {
+        "andel": "0",
+        "inntekt": "0",
+        "periode": 3,
+        "inntektsPeriode": {
+          "sisteMåned": "2017-04",
+          "førsteMåned": "2016-05"
+        },
+        "inneholderFangstOgFisk": false
+      }
+    ]
+  },
+  "periodeResultat": {
+    "sporingsId": "01DBFXH3RHW3V12925Z4J8N3S8",
+    "subsumsjonsId": "01DBFXH3RHDGZAD0A7ZZYNDTKW",
+    "periodeAntallUker": 52,
+    "regelIdentifikator": "Periode.v1"
+  },
+  "satsResultat": {
+    "dagsats": 360,
+    "ukesats": 1800,
+    "sporingsId": "01DBFXH3VP92K6QB3K6TG2V22P",
+    "subsumsjonsId": "01DBFXH3VP2FKZG331B0S9VE04",
+    "regelIdentifikator": "Sats.v1",
+    "benyttet90ProsentRegel": false
+  }
+}


### PR DESCRIPTION
resolves #19 

La til vilkårtester for å vurdere minsteinntekt før bestilling av oppgave for ny søknad i arena. Dette vil la oss tagge disse oppgavene i arena for å lette på saksbehandling. 

Vilkårstesteren er koblet på innløpet som en kjede i behandlingslenken, og er styrt av en feature toggle. 