### PR TITLE
Route oppgaver for mulig avslag til egen benk

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Behandlingslenke.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Behandlingslenke.kt
@@ -71,18 +71,18 @@ internal class NyttSaksforholdBehandlingslenke(private val arena: ArenaClient, n
                     PacketMapper.registrertDatoFrom(packet)
                 )
 
-            val oppfyllerMinsteinntekt = packet.getNullableBoolean(PacketKeys.OPPFYLLER_MINSTEINNTEKT) == false
+            val kanAvslåsPåMinsteinntekt = packet.getNullableBoolean(PacketKeys.OPPFYLLER_MINSTEINNTEKT) == false
 
             val fagsakId: FagsakId? = arena.bestillOppgave(
                 StartVedtakCommand(
                     naturligIdent = PacketMapper.bruker(packet).id,
-                    behandlendeEnhetId = when (oppfyllerMinsteinntekt) {
+                    behandlendeEnhetId = when (kanAvslåsPåMinsteinntekt) {
                         true -> ENHET_FOR_HURTIGE_AVSLAG
                         false -> PacketMapper.tildeltEnhetsNrFrom(packet)
                     },
                     tilleggsinformasjon = tilleggsinformasjon,
                     registrertDato = PacketMapper.registrertDatoFrom(packet),
-                    oppgavebeskrivelse = when (oppfyllerMinsteinntekt) {
+                    oppgavebeskrivelse = when (kanAvslåsPåMinsteinntekt) {
                         true -> "Minsteinntekt - mulig avslag\n"
                         false -> PacketMapper.henvendelse(packet).oppgavebeskrivelse
                     }

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Behandlingslenke.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Behandlingslenke.kt
@@ -66,6 +66,7 @@ internal class NyttSaksforholdBehandlingslenke(
             PacketMapper.harIkkeFagsakId(packet) &&
             PacketMapper.henvendelse(packet) == NyttSaksforhold &&
             arena.harIkkeAktivSak(PacketMapper.bruker(packet))
+                .also { if (!it) Metrics.automatiskJournalførtNeiTellerInc("aktiv_sak", PacketMapper.tildeltEnhetsNrFrom(packet)) }
 
     override fun håndter(packet: Packet): Packet {
         if (kanBehandle(packet)) {
@@ -190,7 +191,6 @@ internal class FerdigstillJournalpostBehandlingslenke(
         if (kanBehandle(packet)) {
             journalpostApi.ferdigstill(packet.getStringValue(PacketKeys.JOURNALPOST_ID))
             logger.info { "Automatisk journalført" }
-            Metrics.automatiskJournalførtJaTellerInc()
         }
         return neste?.håndter(packet) ?: packet
     }

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstill.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstill.kt
@@ -5,7 +5,6 @@ import mu.KotlinLogging
 import no.finn.unleash.Unleash
 import no.nav.dagpenger.events.Packet
 import no.nav.dagpenger.events.moshiInstance
-import no.nav.dagpenger.journalføring.ferdigstill.PacketMapper.bruker
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaClient
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.Avsender
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.Bruker
@@ -104,7 +103,7 @@ internal class JournalføringFerdigstill(
     val ferdigstillOppgaveLenke = FerdigstillJournalpostBehandlingslenke(journalPostApi, manuellOppgaveLenke)
     val oppdaterLenke = OppdaterJournalpostBehandlingslenke(journalPostApi, ferdigstillOppgaveLenke)
     val eksisterendeSakLenke = EksisterendeSaksForholdBehandlingslenke(arenaClient, oppdaterLenke)
-    val nySakLenke = NyttSaksforholdBehandlingslenke(arenaClient, eksisterendeSakLenke)
+    val nySakLenke = NyttSaksforholdBehandlingslenke(arenaClient, unleash, eksisterendeSakLenke)
     val vilkårtestingLenke = OppfyllerMinsteinntektBehandlingsLenke(vilkårtester, unleash, nySakLenke)
 
     fun handlePacket(packet: Packet): Packet {

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Metrics.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Metrics.kt
@@ -19,11 +19,14 @@ internal object Metrics {
         .build()
         .name("automatisk_journalfort_arena")
         .help("Antall søknader som er automatisk journalført i Arena")
-        .labelNames("opprettet", "grunn")
+        .labelNames("opprettet", "grunn", "enhet")
         .register()
 
-    fun automatiskJournalførtJaTellerInc() = automatiskJournalførtTeller.labels("true", "arena_ok").inc()
-    fun automatiskJournalførtNeiTellerInc(reason: String) = automatiskJournalførtTeller.labels("false", reason).inc()
+    fun automatiskJournalførtJaTellerInc(enhet: String) =
+        automatiskJournalførtTeller.labels("true", "arena_ok", enhet).inc()
+
+    fun automatiskJournalførtNeiTellerInc(reason: String, enhet: String) =
+        automatiskJournalførtTeller.labels("false", reason, enhet).inc()
 
     private val inngangsvilkårResultatTeller = Counter
         .build()
@@ -32,5 +35,6 @@ internal object Metrics {
         .labelNames("oppfyller")
         .register()
 
-    fun inngangsvilkårResultatTellerInc(oppfyllerKrav: Boolean) = inngangsvilkårResultatTeller.labels(oppfyllerKrav.toString()).inc()
+    fun inngangsvilkårResultatTellerInc(oppfyllerKrav: Boolean) =
+        inngangsvilkårResultatTeller.labels(oppfyllerKrav.toString()).inc()
 }

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillTest.kt
@@ -239,7 +239,7 @@ internal class JournalføringFerdigstillTest {
             )
         val journalPostId = "journalPostId"
         val naturligIdent = "12345678910"
-        val behandlendeEnhet = "9999"
+        val behandlendeEnhet = ENHET_FOR_HURTIGE_AVSLAG
 
         val slot = slot<OppgaveCommand>()
 
@@ -259,6 +259,7 @@ internal class JournalføringFerdigstillTest {
 
         slot.captured.shouldBeTypeOf<StartVedtakCommand>()
         slot.captured.oppgavebeskrivelse shouldBe "Minsteinntekt - mulig avslag\n"
+        slot.captured.behandlendeEnhetId shouldBe behandlendeEnhet
     }
 
     private fun testHenvendelseAngåendeEksisterendeSaksforhold(henvendelsestype: String) {

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/JournalføringFerdigstillTest.kt
@@ -128,7 +128,13 @@ internal class JournalføringFerdigstillTest {
     @Test
     fun `Opprett manuell journalføringsoppgave når bruker er ukjent`() {
         val journalFøringFerdigstill =
-            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient, mockk(), FakeUnleash())
+            JournalføringFerdigstill(
+                journalPostApi,
+                manuellJournalføringsOppgaveClient,
+                arenaClient,
+                mockk(),
+                FakeUnleash()
+            )
         val journalPostId = "journalPostId"
         val dato = "2020-01-01T01:01:01"
         val zonedDateTime = LocalDateTime.parse(dato).atZone(ZoneId.of("Europe/Oslo"))
@@ -165,7 +171,13 @@ internal class JournalføringFerdigstillTest {
     @Test
     fun `Opprett fagsak og oppgave, og ferdigstill, når bruker ikke har aktiv fagsak`() {
         val journalFøringFerdigstill =
-            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient, mockk(), FakeUnleash())
+            JournalføringFerdigstill(
+                journalPostApi,
+                manuellJournalføringsOppgaveClient,
+                arenaClient,
+                mockk(),
+                FakeUnleash()
+            )
         val journalPostId = "journalPostId"
         val naturligIdent = "12345678910"
         val behandlendeEnhet = "9999"
@@ -235,11 +247,14 @@ internal class JournalføringFerdigstillTest {
                 manuellJournalføringsOppgaveClient,
                 arenaClient,
                 vilkårtester,
-                FakeUnleash().apply { enableAll() }
+                FakeUnleash().apply {
+                    enable("dagpenger-journalforing-ferdigstill.vilkaartesting")
+                    disable("dagpenger-journalforing-ferdigstill.bruk_hurtig_enhet")
+                }
             )
         val journalPostId = "journalPostId"
         val naturligIdent = "12345678910"
-        val behandlendeEnhet = ENHET_FOR_HURTIGE_AVSLAG
+        val behandlendeEnhet = "4450"
 
         val slot = slot<OppgaveCommand>()
 
@@ -259,12 +274,54 @@ internal class JournalføringFerdigstillTest {
 
         slot.captured.shouldBeTypeOf<StartVedtakCommand>()
         slot.captured.oppgavebeskrivelse shouldBe "Minsteinntekt - mulig avslag\n"
-        slot.captured.behandlendeEnhetId shouldBe behandlendeEnhet
+        slot.captured.behandlendeEnhetId shouldBe "4450"
+    }
+
+    @Test
+    fun `Ved kandidat for avslag basert på minsteinntekt havner på egen kø om feature flag er på`() {
+        val vilkårtester = mockk<Vilkårtester>()
+        val journalFøringFerdigstill =
+            JournalføringFerdigstill(
+                journalPostApi,
+                manuellJournalføringsOppgaveClient,
+                arenaClient,
+                vilkårtester,
+                FakeUnleash().apply { enableAll() }
+            )
+        val journalPostId = "journalPostId"
+        val naturligIdent = "12345678910"
+        val behandlendeEnhet = "4450"
+
+        val slot = slot<OppgaveCommand>()
+
+        every { vilkårtester.harBeståttMinsteArbeidsinntektVilkår(any()) } returns false
+        every { arenaClient.bestillOppgave(command = capture(slot)) } returns null
+        every { arenaClient.harIkkeAktivSak(any()) } returns true
+
+        val packet = lagPacket(journalPostId, naturligIdent, behandlendeEnhet, "NY_SØKNAD")
+
+        journalFøringFerdigstill.handlePacket(packet)
+
+        verify {
+            arenaClient.bestillOppgave(any())
+            journalPostApi.oppdater(journalPostId, any())
+            journalPostApi.ferdigstill(journalPostId)
+        }
+
+        slot.captured.shouldBeTypeOf<StartVedtakCommand>()
+        slot.captured.oppgavebeskrivelse shouldBe "Minsteinntekt - mulig avslag\n"
+        slot.captured.behandlendeEnhetId shouldBe ENHET_FOR_HURTIGE_AVSLAG
     }
 
     private fun testHenvendelseAngåendeEksisterendeSaksforhold(henvendelsestype: String) {
         val journalFøringFerdigstill =
-            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient, mockk(), FakeUnleash())
+            JournalføringFerdigstill(
+                journalPostApi,
+                manuellJournalføringsOppgaveClient,
+                arenaClient,
+                mockk(),
+                FakeUnleash()
+            )
         val journalPostId = "journalPostId"
         val naturligIdent = "12345678910"
         val behandlendeEnhet = "9999"
@@ -318,7 +375,13 @@ internal class JournalføringFerdigstillTest {
     @Test
     fun `Opprett manuell journalføringsoppgave når bruker har aktiv fagsak`() {
         val journalFøringFerdigstill =
-            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient, mockk(), FakeUnleash())
+            JournalføringFerdigstill(
+                journalPostApi,
+                manuellJournalføringsOppgaveClient,
+                arenaClient,
+                mockk(),
+                FakeUnleash()
+            )
         val journalPostId = "journalPostId"
         val naturligIdent = "12345678910"
         val behandlendeEnhet = "9999"
@@ -353,7 +416,13 @@ internal class JournalføringFerdigstillTest {
     @Test
     fun `Opprett manuell journalføringsoppgave når bestilling av arena-oppgave feiler`() {
         val journalFøringFerdigstill =
-            JournalføringFerdigstill(journalPostApi, manuellJournalføringsOppgaveClient, arenaClient, mockk(), FakeUnleash())
+            JournalføringFerdigstill(
+                journalPostApi,
+                manuellJournalføringsOppgaveClient,
+                arenaClient,
+                mockk(),
+                FakeUnleash()
+            )
         val journalPostId = "journalPostId"
         val naturligIdent = "12345678910"
         val behandlendeEnhet = "9999"

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/NyttSaksforholdBehandlingslenkeTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/NyttSaksforholdBehandlingslenkeTest.kt
@@ -3,6 +3,7 @@ package no.nav.dagpenger.journalføring.ferdigstill
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.finn.unleash.FakeUnleash
 import no.nav.dagpenger.events.Packet
 import no.nav.dagpenger.journalføring.ferdigstill.adapter.ArenaClient
 import org.junit.Test
@@ -16,7 +17,7 @@ internal class NyttSaksforholdBehandlingslenkeTest {
         val nesteKjede: Behandlingslenke = mockk()
 
         val nyArenaSakKjede = NyttSaksforholdBehandlingslenke(
-            arena = arenaMock, neste = nesteKjede
+            arena = arenaMock, toggle = FakeUnleash(), neste = nesteKjede
 
         )
         val packet = Packet().apply {


### PR DESCRIPTION
NAY ønsker å teste effekten av å avslå saker som ikke oppfyller kravene
til minsteinntekt på en kjapp måte.

Det betyr at de trenger en egen benk å plukke av.

Bare ikke-permitterte skal på egen benk, 4403.
Permitterte skal fortsatt gå på samme benk: 4455