### PR TITLE
Tiltak 1:

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Application.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/Application.kt
@@ -40,9 +40,8 @@ internal class Application(
             )
             logger.info { "Processing: $packet" }
 
-            if (packet.getReadCount() >= 10 && packet.getStringValue(PacketKeys.JOURNALPOST_ID) != "471331953") {
-                logger.error { "Read count >= 10 for packet with journalpostid ${packet.getStringValue(PacketKeys.JOURNALPOST_ID)}" }
-                throw ReadCountException()
+            if (packet.getReadCount() >= 10) {
+                logger.warn { "Read count >= 10 for packet with journalpostid ${packet.getStringValue(PacketKeys.JOURNALPOST_ID)}" }
             }
 
             return journalføringFerdigstill.handlePacket(packet)
@@ -111,5 +110,3 @@ fun main() {
 
     Application(configuration, journalFøringFerdigstill).start()
 }
-
-class ReadCountException : RuntimeException()

--- a/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/arena/SoapArenaClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/arena/SoapArenaClient.kt
@@ -129,6 +129,7 @@ class SoapArenaClient(
     override fun status(): HealthStatus {
         return try {
             oppgaveV1.ping()
+            ytelseskontraktV3.ping()
             HealthStatus.UP
         } catch (e: Exception) {
             HealthStatus.DOWN

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/KafkaFeilhåndteringTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/KafkaFeilhåndteringTest.kt
@@ -2,7 +2,6 @@ package no.nav.dagpenger.journalføring.ferdigstill
 
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
-import io.kotlintest.shouldThrow
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -102,43 +101,6 @@ class KafkaFeilhåndteringTest {
         }
 
         verify(exactly = 1) { arenaClient.bestillOppgave(any()) }
-    }
-
-    @Test
-    fun `skal feile hvis pakken er lest mer enn 10 ganger`() {
-        val application = Application(configuration, mockk())
-
-        val journalPostId = "journalPostId"
-        val naturligIdent = "12345678910"
-        val behandlendeEnhet = "9999"
-        val aktørId = "987654321"
-
-        val packet = Packet("{\"system_read_count\": 9}").apply {
-            this.putValue(PacketKeys.JOURNALPOST_ID, journalPostId)
-            this.putValue(PacketKeys.TOGGLE_BEHANDLE_NY_SØKNAD, true)
-            this.putValue(PacketKeys.NATURLIG_IDENT, naturligIdent)
-            this.putValue(PacketKeys.BEHANDLENDE_ENHET, behandlendeEnhet)
-            this.putValue(PacketKeys.DATO_REGISTRERT, "2020-01-01")
-            this.putValue(PacketKeys.AKTØR_ID, aktørId)
-            this.putValue(PacketKeys.AVSENDER_NAVN, "Donald")
-            this.putValue(PacketKeys.HENVENDELSESTYPE, "NY_SØKNAD")
-            PacketMapper.dokumentJsonAdapter.toJsonValue(
-                listOf(
-                    Dokument(
-                        "id1",
-                        "tittel1"
-                    )
-                )
-            )?.let {
-                this.putValue(
-                    PacketKeys.DOKUMENTER, it
-                )
-            }
-        }
-
-        shouldThrow<ReadCountException> {
-            application.onPacket(packet)
-        }
     }
 
     private fun readOutput(topologyTestDriver: TopologyTestDriver): ProducerRecord<String, Packet>? {

--- a/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/arena/SoapArenaClientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/journalføring/ferdigstill/adapter/soap/arena/SoapArenaClientTest.kt
@@ -90,22 +90,31 @@ internal class SoapArenaClientTest {
     @Test
     fun ` helsesjekk skal være ok når Arena er oppe`() {
         val behandleArbeidOgAktivitetOppgaveV1: BehandleArbeidOgAktivitetOppgaveV1 = mockk()
+        val ytelseskontraktV3: YtelseskontraktV3 = mockk()
         every {
             behandleArbeidOgAktivitetOppgaveV1.ping()
         } returns Unit
 
-        val client = SoapArenaClient(behandleArbeidOgAktivitetOppgaveV1, mockk())
-        client.status() shouldBe HealthStatus.UP
+        every {
+            ytelseskontraktV3.ping()
+        } returns Unit
+
+        SoapArenaClient(behandleArbeidOgAktivitetOppgaveV1, ytelseskontraktV3).status() shouldBe HealthStatus.UP
     }
 
     @Test
     fun ` helsesjekk skal ikke være ok når Arena nede`() {
         val behandleArbeidOgAktivitetOppgaveV1: BehandleArbeidOgAktivitetOppgaveV1 = mockk()
+        val ytelseskontraktV3: YtelseskontraktV3 = mockk()
         every {
             behandleArbeidOgAktivitetOppgaveV1.ping()
         } throws RuntimeException()
 
-        val client = SoapArenaClient(behandleArbeidOgAktivitetOppgaveV1, mockk())
-        client.status() shouldBe HealthStatus.DOWN
+        every {
+            ytelseskontraktV3.ping()
+        } returns Unit
+
+
+        SoapArenaClient(behandleArbeidOgAktivitetOppgaveV1, ytelseskontraktV3).status() shouldBe HealthStatus.DOWN
     }
 }


### PR DESCRIPTION
[Bugfix] : Fjerner "sikringen" som sjekker "readcount" på pakka. I og med at vi produserer state i packet tilbake til Kafka (ved feks til AdapterException) vil "chains" som gikk bra ikke bli forsøkt på nytt men "chains" som gikk dårlig forsøkes på nytt.
Det er også opptil hver "chain" til å skrive sin state tilbake til packet.
[Enhancement] : La til begge rpc-metodene vi bruker som en del av helsesjekken for ArenaClient. Sånn for å være sikker.

gh issue: #27 